### PR TITLE
version 2.24.3

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # Bricolage Release Note
 
+## version 5.24.3
+
+- Support ECS task role with my-import job class
+
 ## version 5.24.2
 
 - [fix] --log-dir, --log-path and --s3-log options are wrongly not ommittable

--- a/lib/bricolage/version.rb
+++ b/lib/bricolage/version.rb
@@ -1,4 +1,4 @@
 module Bricolage
   APPLICATION_NAME = 'Bricolage'
-  VERSION = '5.24.2'
+  VERSION = '5.24.3'
 end


### PR DESCRIPTION
Want to release 2.24.3 which includes AWS SDK update in `bin/mys3dump` to support ECS task role with my-import job class.

- [ ] build
```
gem build bricolage.gemspec 
```

- [ ] push
```
gem push bricolage-5.24.3.gem
```

please review