### PR TITLE
[fix] Log mys3dump command output

### DIFF
--- a/lib/bricolage/mysqldatasource.rb
+++ b/lib/bricolage/mysqldatasource.rb
@@ -233,6 +233,7 @@ module Bricolage
         cmd = build_cmd(command_parameters)
         ds.logger.info "[CMD] #{cmd}"
         out, st = Open3.capture2e(environment_variables, cmd)
+        ds.logger.info "[CMDOUT] #{out}"
         unless st.success?
           msg = extract_exception_message(out)
           raise JobFailure, "mys3dump failed (status: #{st.to_i}): #{msg}"


### PR DESCRIPTION
Write mys3dump command output to log. Which is unintentionally remove with https://github.com/bricolages/bricolage/pull/105 .

@aamine 