### PR TITLE
fix: Allows $dest_table to use default value of declarations

### DIFF
--- a/jobclass/create.rb
+++ b/jobclass/create.rb
@@ -18,7 +18,7 @@ JobClass.define('create') {
         task.drop_force_if params['drop']
         task.exec params['table-def']
         task.analyze_if params['analyze']
-        task.grant_if params['grant'], params['dest-table']
+        task.grant_if params['grant'], '$dest_table'
       }
     }
   }

--- a/jobclass/createview.rb
+++ b/jobclass/createview.rb
@@ -17,7 +17,7 @@ JobClass.define('createview') {
       task.transaction {
         task.drop_view_force_if params['drop']
         task.exec params['sql-file']
-        task.grant_if params['grant'], params['dest-table']
+        task.grant_if params['grant'], '$dest_table'
       }
     }
   }

--- a/jobclass/load.rb
+++ b/jobclass/load.rb
@@ -35,9 +35,9 @@ JobClass.define('load') {
         task.transaction {
           task.drop_force '${dest_table}'
           task.exec params['table-def']
-          task.load params['src-ds'], params['src-file'], params['dest-table'],
+          task.load params['src-ds'], params['src-file'], '$dest_table',
               params['format'], params['jsonpath'], params['options']
-          task.grant_if params['grant'], params['dest-table']
+          task.grant_if params['grant'], '$dest_table'
         }
         # ANALYZE, VACUUM is needless for newly loaded table, skip always.
 
@@ -49,9 +49,9 @@ JobClass.define('load') {
 
         task.truncate_if params['truncate']
         task.transaction {
-          task.load params['src-ds'], params['src-file'], params['dest-table'],
+          task.load params['src-ds'], params['src-file'], '$dest_table',
               params['format'], params['jsonpath'], params['options']
-          task.grant_if params['grant'], params['dest-table']
+          task.grant_if params['grant'], '$dest_table'
         }
         # ANALYZE, VACUUM is needless for newly loaded table, skip always.
 
@@ -59,9 +59,9 @@ JobClass.define('load') {
         # load only pattern
 
         task.transaction {
-          task.load params['src-ds'], params['src-file'], params['dest-table'],
+          task.load params['src-ds'], params['src-file'], '$dest_table',
               params['format'], params['jsonpath'], params['options']
-          task.grant_if params['grant'], params['dest-table']
+          task.grant_if params['grant'], '$dest_table'
           task.analyze_if params['analyze']
         }
         # We cannot execute VACUUM in transaction

--- a/jobclass/rebuild-drop.rb
+++ b/jobclass/rebuild-drop.rb
@@ -23,19 +23,19 @@ JobClass.define('rebuild-drop') {
     script.task(params['data-source']) {|task|
       task.transaction {
         # CREATE
-        task.drop_force params['dest-table']
+        task.drop_force '$dest_table'
         task.exec params['table-def']
 
         # INSERT
         task.exec params['sql-file']
 
         # GRANT
-        task.grant_if params['grant'], params['dest-table']
+        task.grant_if params['grant'], '$dest_table'
       }
 
       # VACUUM, ANALYZE
-      task.vacuum_if params['vacuum'], params['vacuum-sort'], params['dest-table']
-      task.analyze_if params['analyze'], params['dest-table']
+      task.vacuum_if params['vacuum'], params['vacuum-sort'], '$dest_table'
+      task.analyze_if params['analyze'], '$dest_table'
     }
   }
 }

--- a/jobclass/rebuild-rename.rb
+++ b/jobclass/rebuild-rename.rb
@@ -21,6 +21,7 @@ JobClass.define('rebuild-rename') {
 
   script {|params, script|
     script.task(params['data-source']) {|task|
+      dest_table = '$dest_table'
       prev_table = '${dest_table}_old'
       work_table = '${dest_table}_wk'
 
@@ -43,10 +44,9 @@ JobClass.define('rebuild-rename') {
 
       # RENAME
       task.transaction {
-        task.create_dummy_table '$dest_table'
-        dest_table = params['dest-table']
-        task.rename_table dest_table.to_s, "#{dest_table.name}_old"
-        task.rename_table "#{dest_table}_wk", dest_table.name
+        task.create_dummy_table dest_table
+        task.rename_table dest_table, prev_table
+        task.rename_table work_table, dest_table
       }
     }
   }

--- a/jobclass/sql.rb
+++ b/jobclass/sql.rb
@@ -25,7 +25,7 @@ JobClass.define('sql') {
       task.exec params['sql-file']
       task.vacuum_if params['vacuum'], params['vacuum-sort']
       task.analyze_if params['analyze']
-      task.grant_if params['grant'], params['dest-table']
+      task.grant_if params['grant'], '$dest_table'
     }
   }
 }


### PR DESCRIPTION
job classスクリプト内で `dest-table` を参照するとき、 `params['dest-table']` を使ってしまうとスクリプトのコンパイル時にすべての変数が展開されてしまう。しかしコンパイル時と実行時だと使える変数が異なる（前者のほうがアクセス可能な変数が少ない）ので、.ctファイルに定義されたデフォルト値などが使えなくなってしまう。

この影響で例えば `bricolage create --table-def=XXXX.ct` を実行すると、たとえ.ctファイルに `dest-table` のデフォルト値が設定されていてもgrant対象テーブル名が空になりエラーになってしまっていたのだが、それは意図していない動きなので解決したい。

