### PR TITLE
[fix] Unload fails when a query has backslash

### DIFF
--- a/lib/bricolage/psqldatasource.rb
+++ b/lib/bricolage/psqldatasource.rb
@@ -395,7 +395,7 @@ module Bricolage
     end
 
     def format_query(query)
-      query.gsub(/^--.*/, '').strip.gsub(/[ \t]*\n[ \t]*/, ' ').gsub("'", "\\\\'")
+      query.gsub(/^--.*/, '').strip.gsub(/[ \t]*\n[ \t]*/, ' ').gsub(/\\/,"\\\\\\\\").gsub("'", "\\\\'")
     end
   end
 


### PR DESCRIPTION
Unload fails with syntax error when a query has
backslash in it.

Example query with backslash
```
select
    replace(column, '\\','\\\\')
from
    table
;
```

Generated unload query
```
unload ('select replace(column, \'\\\',\'\\\\\') from table;')
```

Error message
```
ERROR:  syntax error at or near "\"
LINE 1: unload ('select replace(column, \'\\\',\'\\\\\') from table...
```

`replace(column, \'\\\',\'\\\\\')` should be
`replace(column,\'\\\\\',\'\\\\\\\\\')`.