### PR TITLE
Add database task queue

### DIFF
--- a/bricolage.gemspec
+++ b/bricolage.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'test-unit'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'mocha'
+  s.add_development_dependency 'pry-byebug'
 end

--- a/lib/bricolage/dao/job.rb
+++ b/lib/bricolage/dao/job.rb
@@ -25,7 +25,7 @@ module Bricolage
           ;
         SQL
 
-        if job.empty?
+        if job.nil?
           nil
         else
           Attributes.new(job['job_id'], job['subsystem'], job['job_name'], job['jobnet_id'])

--- a/lib/bricolage/dao/job.rb
+++ b/lib/bricolage/dao/job.rb
@@ -26,17 +26,16 @@ module Bricolage
         SQL
 
         if job.empty?
-          []
+          nil
         else
           Attributes.new(job['job_id'], job['subsystem'], job['job_name'], job['jobnet_id'])
         end
       end
 
-      def create_if_not_exist(subsystem, job_name, jobnet_id)
+      def create(subsystem, job_name, jobnet_id)
         job = @conn.query_row(<<~SQL)
           insert into jobs ("subsystem", "job_name", jobnet_id)
               values ('#{subsystem}', '#{job_name}', #{jobnet_id})
-              on conflict ("subsystem", "job_name", jobnet_id) do nothing
               returning "job_id", "subsystem", "job_name", jobnet_id
           ;
         SQL
@@ -45,7 +44,7 @@ module Bricolage
       end
 
       def find_or_create(subsystem, job_name, jobnet_id)
-        find(subsystem, job_name, jobnet_id) || create_if_not_exist(subsystem, job_name, jobnet_id)
+        find(subsystem, job_name, jobnet_id) || create(subsystem, job_name, jobnet_id)
       end
     end
   end

--- a/lib/bricolage/dao/job.rb
+++ b/lib/bricolage/dao/job.rb
@@ -19,8 +19,8 @@ module Bricolage
           from
               jobs
           where
-              "subsystem" = '#{subsystem}'
-              and "job_name" = '#{job_name}'
+              "subsystem" = '#{escape(subsystem)}'
+              and "job_name" = '#{escape(job_name)}'
               and jobnet_id = #{jobnet_id}
           ;
         SQL
@@ -35,7 +35,7 @@ module Bricolage
       def create(subsystem, job_name, jobnet_id)
         job = @conn.query_row(<<~SQL)
           insert into jobs ("subsystem", "job_name", jobnet_id)
-              values ('#{subsystem}', '#{job_name}', #{jobnet_id})
+              values ('#{escape(subsystem)}', '#{escape(job_name)}', #{jobnet_id})
               returning "job_id", "subsystem", "job_name", jobnet_id
           ;
         SQL
@@ -45,6 +45,13 @@ module Bricolage
 
       def find_or_create(subsystem, job_name, jobnet_id)
         find(subsystem, job_name, jobnet_id) || create(subsystem, job_name, jobnet_id)
+      end
+
+      private
+
+      def escape(string)
+        return string unless string
+        string.to_s.gsub(/'/, "''").gsub(/\\/, '\\\\')
       end
     end
   end

--- a/lib/bricolage/dao/job.rb
+++ b/lib/bricolage/dao/job.rb
@@ -2,6 +2,8 @@ module Bricolage
   module DAO
     class Job
 
+      include SQLUtils
+
       Attributes = Struct.new(:id, :subsystem, :job_name, :jobnet_id)
 
       def initialize(datasource)
@@ -19,8 +21,8 @@ module Bricolage
           from
               jobs
           where
-              "subsystem" = '#{escape(subsystem)}'
-              and "job_name" = '#{escape(job_name)}'
+              "subsystem" = #{s(subsystem)}
+              and "job_name" = #{s(job_name)}
               and jobnet_id = #{jobnet_id}
           ;
         SQL
@@ -35,7 +37,7 @@ module Bricolage
       def create(subsystem, job_name, jobnet_id)
         job = @conn.query_row(<<~SQL)
           insert into jobs ("subsystem", "job_name", jobnet_id)
-              values ('#{escape(subsystem)}', '#{escape(job_name)}', #{jobnet_id})
+              values (#{s(subsystem)}, #{s(job_name)}, #{jobnet_id})
               returning "job_id", "subsystem", "job_name", jobnet_id
           ;
         SQL
@@ -45,13 +47,6 @@ module Bricolage
 
       def find_or_create(subsystem, job_name, jobnet_id)
         find(subsystem, job_name, jobnet_id) || create(subsystem, job_name, jobnet_id)
-      end
-
-      private
-
-      def escape(string)
-        return string unless string
-        string.to_s.gsub(/'/, "''").gsub(/\\/, '\\\\')
       end
     end
   end

--- a/lib/bricolage/dao/job.rb
+++ b/lib/bricolage/dao/job.rb
@@ -1,0 +1,40 @@
+module Bricolage
+  module DAO
+    class Job
+
+      Job = Struct.new(:id, :subsystem, :job_name, :jobnet_id)
+
+      def initialize(datasource)
+        @datasource = datasource
+      end
+
+      def find(subsystem, job_name, jobnet_id)
+        job = @datasource.open do |conn|
+          conn.query_row(<<~SQL)
+          SELECT * FROM jobs WHERE subsystem = '#{subsystem}' AND job_name = '#{job_name}' AND jobnet_id = #{jobnet_id};
+          SQL
+        end
+
+        Job.new(job['job_id'], job['subsystem'], job['job_name'], job['jobnet_id']) unless job.empty?
+      end
+
+      def create(subsystem, job_name, jobnet_id)
+        job = @datasource.open do |conn|
+          conn.query_row(<<~SQL)
+          INSERT INTO jobs (subsystem, job_name, jobnet_id)
+            VALUES ('#{subsystem}', '#{job_name}', #{jobnet_id})
+            ON CONFLICT (subsystem, job_name, jobnet_id) DO NOTHING
+            RETURNING job_id, subsystem, job_name, jobnet_id
+          ;
+          SQL
+        end
+
+        Job.new(job['job_id'], job['subsystem'], job['job_name'], job['jobnet_id']) unless job.empty?
+      end
+
+      def find_or_create(subsystem, job_name, jobnet_id)
+        find(subsystem, job_name, jobnet_id) || create(subsystem, job_name, jobnet_id)
+      end
+    end
+  end
+end

--- a/lib/bricolage/dao/jobexecution.rb
+++ b/lib/bricolage/dao/jobexecution.rb
@@ -49,6 +49,7 @@ module Bricolage
           where
               je.job_id = j.job_id
               and #{where_clause}
+          returning *
           ;
         SQL
 

--- a/lib/bricolage/dao/jobexecution.rb
+++ b/lib/bricolage/dao/jobexecution.rb
@@ -2,10 +2,19 @@ module Bricolage
   module DAO
     class JobExecution
 
+      include  SQLUtils
+
       Attributes = Struct.new(:jobnet_id, :subsystem, :job_id, :job_execution_id,
                                 :status, :message, :submitted_at, :lock,
                                 :started_at, :finished_at, :source, :job_name, :jobnet_name,
                                 keyword_init: true)
+
+      def JobExecution.for_record(job_executions)
+        job_executions.map do |je|
+          je_sym_hash = Hash[ je.map{|k,v| [k.to_sym, v] } ]
+          Attributes.new(**je_sym_hash)
+        end
+      end
 
       def initialize(datasource)
         @datasource = datasource
@@ -21,7 +30,7 @@ module Bricolage
       end
 
       def where(**args)
-        where_clause = DAO.compile_where_expr(args)
+        where_clause = compile_where_expr(args)
 
         job_executions = @conn.query_rows(<<~SQL)
           select
@@ -43,10 +52,10 @@ module Bricolage
       end
 
       def update(where:, set:)
-        set_columns, set_values = DAO.compile_set_expr(set)
-        set_clause = set.map{|k,v| "#{k} = #{DAO.convert_value(v)}"}.join(', ')
+        set_columns, set_values = compile_set_expr(set)
+        set_clause = set.map{|k,v| "#{k} = #{convert_value(v)}"}.join(', ')
 
-        where_clause = DAO.compile_where_expr(where)
+        where_clause = compile_where_expr(where)
         job_executions = @conn.execute_update(<<~SQL)
           update job_executions je
           set #{set_clause}
@@ -66,8 +75,8 @@ module Bricolage
       end
 
       def upsert(set:)
-        set_columns, set_values = DAO.compile_set_expr(set)
-        set_clause = set.map{|k,v| "#{k} = #{DAO.convert_value(v)}"}.join(', ')
+        set_columns, set_values = compile_set_expr(set)
+        set_clause = set.map{|k,v| "#{k} = #{convert_value(v)}"}.join(', ')
 
         job_executions = @conn.query_rows(<<~SQL)
           insert into job_executions (#{set_columns})
@@ -82,22 +91,65 @@ module Bricolage
         job_executions
       end
 
-      def JobExecution.for_record(job_executions)
-        job_executions.map do |je|
-          je_sym_hash = Hash[ je.map{|k,v| [k.to_sym, v] } ]
-          Attributes.new(**je_sym_hash)
+      private
+
+      def compile_set_expr(values_hash)
+        columns = values_hash.keys.map(&:to_s).join(', ')
+        values = values_hash.values.map{|v| convert_value(v) }.join(', ')
+        return columns, values
+      end
+
+      def convert_value(value)
+        if value == :now
+          'now()'
+        elsif value.nil?
+          "null"
+        elsif value == true or value == false
+          "#{value.to_s}"
+        elsif value.instance_of?(Integer) or value.instance_of?(Float)
+          "#{value.to_s}"
+        elsif value.instance_of?(String) or value.instance_of?(Pathname)
+          "#{s(value.to_s)}"
+        else
+          raise "invalid type for 'value' argument in JobExecution#convert_value: #{value} is #{value.class}"
         end
       end
+
+      def compile_where_expr(conds_hash)
+        conds_hash.map{|k,v| convert_cond(k,v) }.join(' and ')
+      end
+
+      def convert_cond(column, cond)
+        if cond.nil?
+          "#{column} is null"
+        elsif cond.instance_of?(Array) # not support subquery
+          in_clause = cond.map{|c| convert_cond(column, c)}.join(' or ')
+          "(#{in_clause})"
+        elsif cond == true or cond == false
+          "#{column} is #{cond.to_s}"
+        elsif cond.instance_of?(Integer) or cond.instance_of?(Float)
+          "#{column} = #{cond}"
+        elsif cond.instance_of?(String) or cond.instance_of?(Pathname)
+          "#{column} = #{s(cond.to_s)}"
+        else
+          raise "invalid type for 'cond' argument in JobExecution#convert_cond: #{cond} is #{cond.class}"
+        end
+      end
+
+
     end
 
     class JobExecutionState
+
+      include SQLUtils
+
       def self.job_executions_change(connection, job_executions)
         state = new(connection)
         job_executions.each do |je|
           state.create(
             job_execution_id: je.job_execution_id,
-            status: je.status,
-            message: je.message,
+            status: je.status || '',
+            message: je.message || '',
             job_id: je.job_id
           )
         end
@@ -109,59 +161,12 @@ module Bricolage
 
       def create(job_execution_id:, status:, message:, job_id:)
         columns = 'job_execution_id, status, message, created_at, job_id'
-        values = "#{job_execution_id}, '#{DAO.escape(status)}', '#{DAO.escape(message)}', now(), #{job_id}"
+        values = "#{job_execution_id}, #{s(status)}, #{s(message)}, now(), #{job_id}"
         @conn.execute("insert into job_execution_states (#{columns}) values (#{values});")
+      rescue
+        require 'pry'
+        binding.pry
       end
-    end
-
-    private
-
-    def self.compile_set_expr(values_hash)
-      columns = values_hash.keys.map(&:to_s).join(', ')
-      values = values_hash.values.map{|v| convert_value(v) }.join(', ')
-      return columns, values
-    end
-
-    def self.convert_value(value)
-      if value == :now
-        'now()'
-      elsif value.nil?
-        "null"
-      elsif value == true or value == false
-        "#{value.to_s}"
-      elsif value.instance_of?(Integer) or value.instance_of?(Float)
-        "#{value.to_s}"
-      elsif value.instance_of?(String) or value.instance_of?(Pathname)
-        "'#{escape(value)}'"
-      else
-        raise "invalid type for 'value' argument in JobExecution.convert_value: #{value} is #{value.class}"
-      end
-    end
-
-    def self.compile_where_expr(conds_hash)
-      conds_hash.map{|k,v| self.convert_cond(k,v) }.join(' and ')
-    end
-
-    def self.convert_cond(column, cond)
-      if cond.nil?
-        "#{column} is null"
-      elsif cond.instance_of?(Array) # not support subquery
-        in_clause = cond.map{|c| self.convert_cond(column, c)}.join(' or ')
-        "(#{in_clause})"
-      elsif cond == true or cond == false
-        "#{column} is #{cond.to_s}"
-      elsif cond.instance_of?(Integer) or cond.instance_of?(Float)
-        "#{column} = #{cond}"
-      elsif cond.instance_of?(String) or cond.instance_of?(Pathname)
-        "#{column} = '#{escape(cond)}'"
-      else
-        raise "invalid type for 'cond' argument in JobExecution.convert_cond: #{cond} is #{cond.class}"
-      end
-    end
-
-    def self.escape(string)
-      return string unless string
-      string.to_s.gsub(/'/, "''").gsub(/\\/, '\\\\')
     end
   end
 end

--- a/lib/bricolage/dao/jobexecution.rb
+++ b/lib/bricolage/dao/jobexecution.rb
@@ -1,0 +1,164 @@
+module Bricolage
+  module DAO
+    class JobExecution
+
+      JobExecution = Struct.new(:jobnet_id, :subsystem, :job_id, :job_execution_id,
+                                :status, :message, :submitted_at, :lock,
+                                :started_at, :finished_at, :source, :job_name, :jobnet_name,
+                                keyword_init: true)
+
+      def initialize(datasource)
+        @datasource = datasource
+      end
+
+      def find_by(**args)
+        where_clause = DAO.parse_where(args)
+
+        job_executions = @datasource.open do |conn|
+          conn.query_rows(<<~SQL)
+          SELECT
+            *
+          FROM
+            job_executions je
+            JOIN jobs j using(job_id)
+            JOIN jobnets jn using(jobnet_id, subsystem)
+          WHERE #{where_clause}
+          ;
+          SQL
+        end
+
+        JobExecution.to_struct(job_executions)
+      end
+
+      def update(where:, set:)
+        set_clause = set.reject{|k,v| v.nil?}.map{|k,v| "#{k} = #{DAO.convert_value(v)}"}.join(', ')
+        where_clause = DAO.parse_where(where)
+
+        job_executions = @datasource.open do |conn|
+          conn.query_rows(<<~SQL)
+          UPDATE
+              job_executions
+          SET
+              #{set_clause}
+          FROM
+              job_executions je
+              JOIN jobs j using(job_id)
+              JOIN jobnets jn using(jobnet_id, subsystem)
+          WHERE
+              #{where_clause}
+          RETURNING *
+          ;
+          SQL
+        end
+        job_executions = JobExecution.to_struct(job_executions)
+
+        JobExecutionState.job_executions_change(@datasource, job_executions)
+
+        job_executions
+      end
+
+      def upsert(where:, set:)
+        set_columns, set_values = DAO.parse_set(set)
+        where_clause = DAO.parse_where(where)
+
+        job_executions = @datasource.open do |conn|
+          conn.query_rows(<<~SQL)
+          INSERT INTO
+              job_executions (#{set_columns})
+          SELECT
+              #{set_values}
+          FROM
+              jobs
+          WHERE
+              #{where_clause}
+          ON CONFLICT  DO NOTHING
+          RETURNING *
+          ;
+          SQL
+        end
+
+        job_executions = JobExecution.to_struct(job_executions)
+
+        JobExecutionState.job_executions_change(@datasource, job_executions)
+
+        job_executions
+      end
+
+      def JobExecution.to_struct(job_executions)
+        if job_executions.empty?
+          []
+        else
+          job_executions.map do |je|
+            je_sym_hash = Hash[ je.map{|k,v| [k.to_sym, v] } ]
+            JobExecution.new(**je_sym_hash)
+          end
+        end
+      end
+
+    end
+
+
+    class JobExecutionState
+      def self.job_executions_change(datasource, job_executions)
+        state = new(datasource)
+        job_executions.each do |je|
+          state.create(
+            job_execution_id: je.job_execution_id,
+            status: je.status,
+            message: je.message,
+            job_id: je.job_id
+          )
+        end
+      end
+
+
+      def initialize(datasource)
+        @datasource = datasource
+      end
+
+      def create(job_execution_id:, status:, message:, job_id:)
+        columns = 'job_execution_id, status, message, created_at, job_id'
+        values = "#{job_execution_id}, '#{status}', '#{message}', NOW(), #{job_id}"
+        @datasource.open do |conn|
+          conn.execute("INSERT INTO job_execution_states (#{columns}) VALUES (#{values});")
+        end
+      end
+    end
+
+
+    private
+
+    def self.parse_set(values_hash)
+      columns = values_hash.keys.map(&:to_s).join(', ')
+      values = values_hash.values.map{|v| convert_value(v) }.join(', ')
+      return columns, values
+    end
+
+    def self.convert_value(value)
+      if value == :now
+        'NOW()'
+      elsif value == true or value == false
+        "#{value}"
+      else
+        "'#{value}'"
+      end
+    end
+
+    def self.parse_where(conds_hash)
+      conds_hash.map{|k,v| self.convet_cond(k,v) }.join(' AND ')
+    end
+
+    def self.convet_cond(column, cond)
+      if cond.nil?
+        "#{column} IS NULL"
+      elsif cond.instance_of?(Array)
+        in_clause = cond.map {|c| "'#{c}'"}.join(', ')
+        "#{column} IN (#{in_clause})"
+      else
+        "#{column} = '#{cond}'"
+      end
+    end
+
+
+  end
+end

--- a/lib/bricolage/dao/jobexecution.rb
+++ b/lib/bricolage/dao/jobexecution.rb
@@ -12,7 +12,7 @@ module Bricolage
         @conn = @datasource.open
       end
 
-      def find_by(**args)
+      def where(**args)
         where_clause = DAO.compile_where_expr(args)
 
         job_executions = @conn.query_rows(<<~SQL)

--- a/lib/bricolage/dao/jobexecution.rb
+++ b/lib/bricolage/dao/jobexecution.rb
@@ -109,7 +109,7 @@ module Bricolage
 
       def create(job_execution_id:, status:, message:, job_id:)
         columns = 'job_execution_id, status, message, created_at, job_id'
-        values = "#{job_execution_id}, '#{status}', '#{message}', now(), #{job_id}"
+        values = "#{job_execution_id}, '#{DAO.escape(status)}', '#{DAO.escape(message)}', now(), #{job_id}"
         @conn.execute("insert into job_execution_states (#{columns}) values (#{values});")
       end
     end
@@ -132,7 +132,7 @@ module Bricolage
       elsif value.instance_of?(Integer) or value.instance_of?(Float)
         "#{value.to_s}"
       elsif value.instance_of?(String) or value.instance_of?(Pathname)
-        "'#{value}'"
+        "'#{escape(value)}'"
       else
         raise "invalid type for 'value' argument in JobExecution.convert_value: #{value} is #{value.class}"
       end
@@ -153,10 +153,15 @@ module Bricolage
       elsif cond.instance_of?(Integer) or cond.instance_of?(Float)
         "#{column} = #{cond}"
       elsif cond.instance_of?(String) or cond.instance_of?(Pathname)
-        "#{column} = '#{cond}'"
+        "#{column} = '#{escape(cond)}'"
       else
         raise "invalid type for 'cond' argument in JobExecution.convert_cond: #{cond} is #{cond.class}"
       end
+    end
+
+    def self.escape(string)
+      return string unless string
+      string.to_s.gsub(/'/, "''").gsub(/\\/, '\\\\')
     end
   end
 end

--- a/lib/bricolage/dao/jobnet.rb
+++ b/lib/bricolage/dao/jobnet.rb
@@ -23,7 +23,7 @@ module Bricolage
           ;
         SQL
 
-        if jobnet.empty?
+        if jobnet.nil?
           nil
         else
           Attributes.new(jobnet['jobnet_id'], jobnet['subsystem'], jobnet['jobnet_name'])

--- a/lib/bricolage/dao/jobnet.rb
+++ b/lib/bricolage/dao/jobnet.rb
@@ -24,17 +24,16 @@ module Bricolage
         SQL
 
         if jobnet.empty?
-          []
+          nil
         else
           Attributes.new(jobnet['jobnet_id'], jobnet['subsystem'], jobnet['jobnet_name'])
         end
       end
 
-      def create_if_not_exist(subsystem, jobnet_name)
+      def create(subsystem, jobnet_name)
         jobnet = @conn.query_row(<<~SQL)
           insert into jobnets ("subsystem", jobnet_name)
               values ('#{subsystem}', '#{jobnet_name}')
-              on conflict ("subsystem", jobnet_name) do nothing
               returning jobnet_id, "subsystem", jobnet_name
           ;
         SQL
@@ -43,7 +42,7 @@ module Bricolage
       end
 
       def find_or_create(subsystem, jobnet_name)
-        find(subsystem, jobnet_name) || create_if_not_exist(subsystem, jobnet_name)
+        find(subsystem, jobnet_name) || create(subsystem, jobnet_name)
       end
     end
   end

--- a/lib/bricolage/dao/jobnet.rb
+++ b/lib/bricolage/dao/jobnet.rb
@@ -1,0 +1,40 @@
+module Bricolage
+  module DAO
+    class JobNet
+
+      JobNet = Struct.new(:id, :subsystem, :jobnet_name)
+
+      def initialize(datasource)
+        @datasource = datasource
+      end
+
+      def find(subsystem, jobnet_name)
+        jobnet = @datasource.open do |conn|
+          conn.query_row(<<~SQL)
+          SELECT *  FROM jobnets WHERE subsystem = '#{subsystem}' AND jobnet_name = '#{jobnet_name}';
+          SQL
+        end
+
+        JobNet.new(jobnet['jobnet_id'], jobnet['subsystem'], jobnet['jobnet_name']) unless jobnet.empty?
+      end
+
+      def create(subsystem, jobnet_name)
+        jobnet = @datasource.open do |conn|
+          conn.query_row(<<~SQL)
+          INSERT INTO jobnets (subsystem, jobnet_name)
+            VALUES ('#{subsystem}', '#{jobnet_name}')
+            ON CONFLICT (subsystem, jobnet_name) DO NOTHING
+            RETURNING jobnet_id, subsystem, jobnet_name
+          ;
+          SQL
+        end
+
+        JobNet.new(jobnet['jobnet_id'], jobnet['subsystem'], jobnet['jobnet_name']) unless jobnet.empty?
+      end
+
+      def find_or_create(subsystem, jobnet_name)
+        find(subsystem, jobnet_name) || create(subsystem, jobnet_name)
+      end
+    end
+  end
+end

--- a/lib/bricolage/dao/jobnet.rb
+++ b/lib/bricolage/dao/jobnet.rb
@@ -2,6 +2,8 @@ module Bricolage
   module DAO
     class JobNet
 
+      include SQLUtils
+
       Attributes = Struct.new(:id, :subsystem, :jobnet_name)
 
       def initialize(datasource)
@@ -18,8 +20,8 @@ module Bricolage
           from
               jobnets
           where
-              "subsystem" = '#{escape(subsystem)}'
-              and jobnet_name = '#{escape(jobnet_name)}'
+              "subsystem" = #{s(subsystem)}
+              and jobnet_name = #{s(jobnet_name)}
           ;
         SQL
 
@@ -33,7 +35,7 @@ module Bricolage
       def create(subsystem, jobnet_name)
         jobnet = @conn.query_row(<<~SQL)
           insert into jobnets ("subsystem", jobnet_name)
-              values ('#{escape(subsystem)}', '#{escape(jobnet_name)}')
+              values (#{s(subsystem)}, #{s(jobnet_name)})
               returning jobnet_id, "subsystem", jobnet_name
           ;
         SQL
@@ -43,13 +45,6 @@ module Bricolage
 
       def find_or_create(subsystem, jobnet_name)
         find(subsystem, jobnet_name) || create(subsystem, jobnet_name)
-      end
-
-      private
-
-      def escape(string)
-        return string unless string
-        string.to_s.gsub(/'/, "''").gsub(/\\/, '\\\\')
       end
     end
   end

--- a/lib/bricolage/dao/jobnet.rb
+++ b/lib/bricolage/dao/jobnet.rb
@@ -18,8 +18,8 @@ module Bricolage
           from
               jobnets
           where
-              "subsystem" = '#{subsystem}'
-              and jobnet_name = '#{jobnet_name}'
+              "subsystem" = '#{escape(subsystem)}'
+              and jobnet_name = '#{escape(jobnet_name)}'
           ;
         SQL
 
@@ -33,7 +33,7 @@ module Bricolage
       def create(subsystem, jobnet_name)
         jobnet = @conn.query_row(<<~SQL)
           insert into jobnets ("subsystem", jobnet_name)
-              values ('#{subsystem}', '#{jobnet_name}')
+              values ('#{escape(subsystem)}', '#{escape(jobnet_name)}')
               returning jobnet_id, "subsystem", jobnet_name
           ;
         SQL
@@ -43,6 +43,13 @@ module Bricolage
 
       def find_or_create(subsystem, jobnet_name)
         find(subsystem, jobnet_name) || create(subsystem, jobnet_name)
+      end
+
+      private
+
+      def escape(string)
+        return string unless string
+        string.to_s.gsub(/'/, "''").gsub(/\\/, '\\\\')
       end
     end
   end

--- a/lib/bricolage/job.rb
+++ b/lib/bricolage/job.rb
@@ -36,18 +36,6 @@ module Bricolage
       }
     end
 
-    def Job.create(jobnet_id, name, ds)
-      subsystem, job_name = name.split('/')
-      ds.open do |conn|
-        conn.execute(<<~SQL)
-          INSERT INTO jobs (subsystem, job_name, jobnet_id)
-            VALUES ('#{subsystem}', '#{job_name}', '#{jobnet_id}')
-            ON CONFLICT (subsystem, job_name, jobnet_id) DO NOTHING
-          ;
-        SQL
-      end
-    end
-
     def initialize(id, job_class, context)
       @id = id
       @job_class = job_class

--- a/lib/bricolage/job.rb
+++ b/lib/bricolage/job.rb
@@ -9,7 +9,7 @@ require 'bricolage/exception'
 require 'fileutils'
 
 module Bricolage
-  
+
   class Job
     # For JobNetRunner
     def Job.load_ref(ref, jobnet_context)
@@ -34,6 +34,19 @@ module Bricolage
       new(id, JobClass.get(class_id), ctx).tap {|job|
         job.init_global_variables
       }
+    end
+
+    def Job.create(jobnet_id, name, ds)
+      subsystem, job_name = name.split('/')
+      ds.open do |conn|
+        conn.execute(<<~SQL)
+          INSERT INTO jobs (subsystem, job_name, jobnet_id)
+            VALUES ('#{subsystem}', '#{job_name}', '#{jobnet_id}')
+            ON CONFLICT (subsystem, job_name, jobnet_id) DO NOTHING
+          ;
+        SQL
+      end
+
     end
 
     def initialize(id, job_class, context)

--- a/lib/bricolage/job.rb
+++ b/lib/bricolage/job.rb
@@ -46,7 +46,6 @@ module Bricolage
           ;
         SQL
       end
-
     end
 
     def initialize(id, job_class, context)

--- a/lib/bricolage/jobnet.rb
+++ b/lib/bricolage/jobnet.rb
@@ -195,27 +195,6 @@ module Bricolage
       Parser.new(ref).parse_stream(jobnet_script)
     end
 
-    def JobNet.find_or_create(name, ds)
-      subsystem, jobnet_name = name.split('/')
-      job_lines = ds.open do |conn|
-        jobnet_id = conn.query_value(<<~SQL)
-          INSERT INTO jobnets (subsystem, jobnet_name)
-            VALUES ('#{subsystem}', '#{jobnet_name}')
-            ON CONFLICT (subsystem, jobnet_name) DO NOTHING
-            RETURNING jobnet_id
-          ;
-        SQL
-        return jobnet_id.to_i if jobnet_id
-
-        jobnet_id = conn.query_value(<<~SQL)
-          SELECT jobnet_id
-          FROM jobnets
-          WHERE subsystem='#{subsystem}' AND jobnet_name='#{jobnet_name}';
-        SQL
-        return jobnet_id.to_i if jobnet_id
-      end
-    end
-
     def initialize(ref, location)
       @ref = ref
       @location = location

--- a/lib/bricolage/jobnet.rb
+++ b/lib/bricolage/jobnet.rb
@@ -195,6 +195,28 @@ module Bricolage
       Parser.new(ref).parse_stream(jobnet_script)
     end
 
+    def JobNet.find_or_create(name, ds)
+      subsystem, jobnet_name = name.split('/')
+      job_lines = ds.open do |conn|
+        jobnet_id = conn.query_value(<<~SQL)
+          INSERT INTO jobnets (subsystem, jobnet_name)
+            VALUES ('#{subsystem}', '#{jobnet_name}')
+            ON CONFLICT (subsystem, jobnet_name) DO NOTHING
+            RETURNING jobnet_id
+          ;
+        SQL
+        return jobnet_id.to_i if jobnet_id
+
+        jobnet_id = conn.query_value(<<~SQL)
+          SELECT jobnet_id
+          FROM jobnets
+          WHERE subsystem='#{subsystem}' AND jobnet_name='#{jobnet_name}';
+        SQL
+        return jobnet_id.to_i if jobnet_id
+      end
+
+    end
+
     def initialize(ref, location)
       @ref = ref
       @location = location

--- a/lib/bricolage/jobnet.rb
+++ b/lib/bricolage/jobnet.rb
@@ -214,7 +214,6 @@ module Bricolage
         SQL
         return jobnet_id.to_i if jobnet_id
       end
-
     end
 
     def initialize(ref, location)

--- a/lib/bricolage/jobnetrunner.rb
+++ b/lib/bricolage/jobnetrunner.rb
@@ -101,8 +101,10 @@ module Bricolage
 
     def get_queue(opts, jobnet)
       if opts.db_name
+        datasource = @ctx.get_data_source('psql', opts.db_name)
+        jobnet = jobnet.jobnets.first
         logger.info "DB connect: #{opts.db_name}"
-        DatabaseTaskQueue.restore_if_exist(@ctx, jobnet)
+        DatabaseTaskQueue.restore_if_exist(datasource, jobnet)
       elsif path = get_queue_file_path(opts)
         logger.info "queue path: #{path}"
         FileTaskQueue.restore_if_exist(path)
@@ -151,6 +153,7 @@ module Bricolage
     end
 
     def run_queue(queue)
+      result = nil
       @hooks.run_before_all_jobs_hooks(BeforeAllJobsEvent.new(@jobnet_id, queue))
       queue.consume_each do |task|
         result = execute_job(task.job, queue)

--- a/lib/bricolage/jobnetrunner.rb
+++ b/lib/bricolage/jobnetrunner.rb
@@ -234,7 +234,8 @@ module Bricolage
         super.merge({
           'local-state-dir' => OptionValue.new('default value', '/tmp/bricolage'),
           'enable-queue' => OptionValue.new('default value', false),
-          'queue-path' => OptionValue.new('default value', nil)
+          'queue-path' => OptionValue.new('default value', nil),
+          'db-name' => OptionValue.new('default value', nil)
         })
       end
       private :opts_default
@@ -284,6 +285,9 @@ Options:
         }
         parser.on('--queue-path=PATH', 'Enables job queue with this path.') {|path|
           @opts_cmdline['queue-path'] = OptionValue.new('--queue-path option', path)
+        }
+        parser.on('--db-name=DB_NAME', 'Enables job queue with this database.') {|db_name|
+          @opts_cmdline['db-name'] = OptionValue.new('--db-name option', db_name)
         }
         parser.on('-c', '--check-only', 'Checks job parameters and quit without executing.') {
           @check_only = true
@@ -355,6 +359,15 @@ Options:
         opt = @opts['queue-path']
         if opt.value
           Pathname(opt.value)
+        else
+          nil
+        end
+      end
+
+      def db_name
+        opt = @opts['db-name']
+        if opt.value
+          opt.value
         else
           nil
         end

--- a/lib/bricolage/jobnetrunner.rb
+++ b/lib/bricolage/jobnetrunner.rb
@@ -58,7 +58,7 @@ module Bricolage
         clear_queue(opts)
         exit EXIT_SUCCESS
       end
-      queue = get_queue(opts)
+      queue = get_queue(opts, jobnet)
       if queue.locked?
         raise ParameterError, "Job queue is still locked. If you are sure to restart jobnet, #{queue.unlock_help}"
       end
@@ -97,10 +97,10 @@ module Bricolage
       end
     end
 
-    def get_queue(opts)
+    def get_queue(opts, jobnet)
       if check_result = check_connect_database(opts)
         logger.info "DB connect: #{check_result}"
-        DatabaseTaskQueue.restore_if_exist(@ctx)
+        DatabaseTaskQueue.restore_if_exist(@ctx, jobnet)
       elsif path = get_queue_file_path(opts)
         logger.info "queue path: #{path}"
         FileTaskQueue.restore_if_exist(path)

--- a/lib/bricolage/jobnetrunner.rb
+++ b/lib/bricolage/jobnetrunner.rb
@@ -98,12 +98,22 @@ module Bricolage
     end
 
     def get_queue(opts)
-      if path = get_queue_file_path(opts)
+      if check_result = check_connect_database(opts)
+        logger.info "DB connect: #{check_result}"
+        DatabaseTaskQueue.restore_if_exist(@ctx)
+      elsif path = get_queue_file_path(opts)
         logger.info "queue path: #{path}"
         FileTaskQueue.restore_if_exist(path)
       else
         TaskQueue.new
       end
+    end
+
+    def check_connect_database(opts)
+      if opts.db_name
+        opts.db_name
+      else
+        nil
     end
 
     def get_queue_file_path(opts)

--- a/lib/bricolage/sqlutils.rb
+++ b/lib/bricolage/sqlutils.rb
@@ -11,7 +11,7 @@ module Bricolage
     alias s sql_string_literal
 
     def escape_sql_string(s)
-      s.gsub(/'/, "''")
+      s.gsub(/'/, "''").gsub(/\\/, '\\\\')
     end
 
     def sql_timestamp_literal(time)

--- a/lib/bricolage/taskqueue.rb
+++ b/lib/bricolage/taskqueue.rb
@@ -141,9 +141,7 @@ module Bricolage
   end
 
   class DatabaseTaskQueue < TaskQueue
-    def DatabaseTaskQueue.restore_if_exist(context, jobnet_ref)
-      datasource = context.get_data_source('psql', 'test_db')
-
+    def DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref)
       subsys, jobnet_name = jobnet_ref.name.delete('*').split('/')
       job_refs = jobnet_ref.refs - [jobnet_ref.start, *jobnet_ref.net_refs, jobnet_ref.end]
       jobnet = Bricolage::DAO::JobNet.new(datasource).find_or_create(subsys, jobnet_name)

--- a/lib/bricolage/taskqueue.rb
+++ b/lib/bricolage/taskqueue.rb
@@ -188,7 +188,7 @@ module Bricolage
     end
 
     def enqueue(task)
-      @jobexecution_dao.update(where: {"subsystem": task.subsystem, job_name: task.job_name},
+      @jobexecution_dao.update(where: {subsystem: task.subsystem, job_name: task.job_name},
                                set:   {status: 'waiting', submitted_at: :now, started_at: nil, finished_at: nil})
       @queue.push task
     end
@@ -208,9 +208,9 @@ module Bricolage
     end
 
     def restore
-      job_executions = @jobexecution_dao.find_by(subsystem: @subsys,
-                                                 jobnet_name: @jobnet_name,
-                                                 status: ['waiting', 'running', 'failed'])
+      job_executions = @jobexecution_dao.where(subsystem: @subsys,
+                                               jobnet_name: @jobnet_name,
+                                               status: ['waiting', 'running', 'failed'])
 
       job_executions.each do |je|
         enqueue JobTask.for_job_execution(je)
@@ -225,7 +225,7 @@ module Bricolage
 
     def locked?
       count = @jobexecution_dao
-                .find_by(subsystem: @subsys, jobnet_name: @jobnet_name, lock: true)
+                .where(subsystem: @subsys, jobnet_name: @jobnet_name, lock: true)
                 .count
       count > 0
     end
@@ -241,7 +241,7 @@ module Bricolage
     end
 
     def locked_records
-      @jobexecution_dao.find_by(subsystem: @subsys, jobnet_name: @jobnet_name, lock: true)
+      @jobexecution_dao.where(subsystem: @subsys, jobnet_name: @jobnet_name, lock: true)
     end
 
     def unlock_help

--- a/schema/Gemfile
+++ b/schema/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'ridgepole'
+gem 'pg'

--- a/schema/Schemafile
+++ b/schema/Schemafile
@@ -2,7 +2,7 @@ create_table "jobs", primary_key: "job_id", force: :cascade do |t|
   t.string  "subsystem", null: false
   t.string  "job_name",  null: false
   t.integer "jobnet_id"
-  t.index ["subsystem", "job_name"], name: "job_unique", unique: true, using: :btree
+  t.index ["subsystem", "job_name", "jobnet_id"], name: "job_unique", unique: true, using: :btree
 end
 
 create_table "jobnets", primary_key: "jobnet_id", force: :cascade do |t|
@@ -16,7 +16,8 @@ create_table "job_executions", primary_key: "job_execution_id", force: :cascade 
   t.string   "message"
   t.datetime "submitted_at", default: -> { "now()" }, null: false
   t.integer  "job_id",       null: false
-  t.datetime "started_at",   null: false
+  t.boolean  "lock", null: false
+  t.datetime "started_at"
   t.datetime "finished_at"
   t.string   "source"
   t.index ["job_id"], name: "job_id_unique", unique: true, using: :btree

--- a/schema/Schemafile
+++ b/schema/Schemafile
@@ -1,0 +1,55 @@
+create_table "jobs", primary_key: "job_id", force: :cascade do |t|
+  t.string  "subsystem", null: false
+  t.string  "job_name",  null: false
+  t.integer "jobnet_id"
+  t.index ["subsystem", "job_name"], name: "job_unique", unique: true, using: :btree
+end
+
+create_table "jobnets", primary_key: "jobnet_id", force: :cascade do |t|
+  t.string "subsystem",   null: false
+  t.string "jobnet_name", null: false
+  t.index ["subsystem", "jobnet_name"], name: "jobnet_unique", unique: true, using: :btree
+end
+
+create_table "job_executions", primary_key: "job_execution_id", force: :cascade do |t|
+  t.string   "status",       null: false
+  t.string   "message"
+  t.datetime "submitted_at", default: -> { "now()" }, null: false
+  t.integer  "job_id",       null: false
+  t.datetime "started_at",   null: false
+  t.datetime "finished_at"
+  t.string   "source"
+  t.index ["job_id"], name: "job_id_unique", unique: true, using: :btree
+end
+
+create_table "job_execution_states", primary_key: "job_execution_state_id", force: :cascade do |t|
+  t.integer  "job_execution_id", null: false
+  t.string   "status",           null: false
+  t.string   "message"
+  t.datetime "created_at", default: -> { "now()" }, null: false
+  t.integer  "job_id",           null: false
+end
+
+add_foreign_key "job_executions",
+                "jobs",
+                column: "job_id",
+                primary_key: "job_id",
+                name: "job_execution_fk_job"
+
+add_foreign_key "job_execution_states",
+                "jobs",
+                column: "job_id",
+                primary_key: "job_id",
+                name: "job_execution_state_fk_job"
+
+add_foreign_key "job_execution_states",
+                "job_executions",
+                column: "job_execution_id",
+                primary_key: "job_execution_id",
+                name: "job_execution_state_fk_job_execution"
+
+add_foreign_key "jobs",
+                "jobnets",
+                column: "jobnet_id",
+                primary_key: "jobnet_id",
+                name: "job_fk_jobnet"

--- a/schema/database.yml
+++ b/schema/database.yml
@@ -1,0 +1,8 @@
+adapter: postgresql
+host: <%= ENV['PGHOST'] || "localhost" %>
+port: 5432
+database: <%= ENV['PGDATABASE'] || "bricolage" %>
+username: <%= ENV['PGUSER'] || "bricolage" %>
+password: <%= ENV['PGPASSWORD'] || "bricolage" %>
+encoding: unicode
+pool: 1

--- a/schema/ridgepole_dryrun.sh
+++ b/schema/ridgepole_dryrun.sh
@@ -1,0 +1,2 @@
+#! /bin/sh
+exec bundle exec ridgepole -f Schemafile -c database.yml --merge --dry-run

--- a/schema/ridgepole_merge.sh
+++ b/schema/ridgepole_merge.sh
@@ -1,0 +1,2 @@
+#! /bin/sh
+exec bundle exec ridgepole -f Schemafile -c database.yml --merge

--- a/test/home/subsys/test_exist.queue
+++ b/test/home/subsys/test_exist.queue
@@ -1,0 +1,1 @@
+subsys/job1

--- a/test/test_taskqueue.rb
+++ b/test/test_taskqueue.rb
@@ -1,0 +1,94 @@
+require 'test/unit'
+require 'bricolage/context'
+require 'bricolage/jobnet'
+require 'bricolage/taskqueue'
+require 'pathname'
+require 'pp'
+require 'pry'
+
+module Bricolage
+  class TestFileTaskQueue < Test::Unit::TestCase
+    exist_queue_path = Pathname.new('test/home/subsys/test_exist.queue')
+    temp_queue_path = Pathname.new('test/home/subsys/test_temp.queue')
+    temp_lock_path = Pathname.new('test/home/subsys/test_temp.queue.LOCK')
+
+    teardown do
+      temp_queue_path.delete if temp_queue_path.exist?
+      temp_lock_path.delete if temp_lock_path.exist?
+    end
+
+    test "FileTaskQueue.restore_if_exist" do
+      queue = FileTaskQueue.restore_if_exist(temp_queue_path)
+      assert_equal 0, queue.size
+      queue = FileTaskQueue.restore_if_exist(exist_queue_path)
+      assert_equal 1, queue.size
+    end
+
+    test "#save" do
+      queue = FileTaskQueue.restore_if_exist(temp_queue_path)
+      assert_false queue.queued?
+      queue.enq JobTask.new('test_dummy_job_task')
+      queue.save
+      assert_true  queue.queued?
+    end
+
+    test "#lock" do
+      queue = FileTaskQueue.restore_if_exist(temp_queue_path)
+      assert_false queue.locked?
+      queue.lock
+      assert_true  queue.locked?
+    end
+
+    test "#unlock" do
+      queue = FileTaskQueue.restore_if_exist(temp_queue_path)
+      queue.lock
+      assert_true  queue.locked?
+      queue.unlock
+      assert_false queue.locked?
+    end
+  end
+
+  class TestDatabaseTaskQueue < Test::Unit::TestCase
+    context = Context.for_application(home_path='test/home')
+    jobnet_path = Pathname.new('test/home/subsys/net1.jobnet')
+    jobnet = RootJobNet.load_auto(context, [jobnet_path]).jobnets.first
+
+    teardown do
+      queue = DatabaseTaskQueue.restore_if_exist(context, jobnet)
+      queue.clear
+    end
+
+    test "DatabaseTaskQueue.restore_if_exist" do
+      queue1 = DatabaseTaskQueue.restore_if_exist(context, jobnet)
+      assert_equal 0, queue1.size
+      queue1.enq JobTask.new('test_dummy_job_task')
+      queue1.save
+      queue2 = DatabaseTaskQueue.restore_if_exist(context, jobnet)
+      assert_equal 1, queue2.size
+    end
+
+    test "#save" do
+      queue = DatabaseTaskQueue.restore_if_exist(context, jobnet)
+      assert_false queue.queued?
+      queue.enq JobTask.new('test_dummy_job_task')
+      queue.save
+      assert_true  queue.queued?
+    end
+
+    test "#lock" do
+      queue = DatabaseTaskQueue.restore_if_exist(context, jobnet)
+      assert_false queue.locked?
+      binding.pry
+      queue.lock
+      assert_true  queue.locked?
+    end
+
+    test "#unlock" do
+      queue = DatabaseTaskQueue.restore_if_exist(context, jobnet)
+      queue.lock
+      assert_true  queue.locked?
+      queue.unlock
+      assert_false queue.locked?
+    end
+  end
+end

--- a/test/test_taskqueue.rb
+++ b/test/test_taskqueue.rb
@@ -5,7 +5,6 @@ require 'bricolage/jobnet'
 require 'bricolage/taskqueue'
 require 'pathname'
 require 'pp'
-require 'pry'
 
 module Bricolage
   class TestFileTaskQueue < Test::Unit::TestCase
@@ -28,7 +27,7 @@ module Bricolage
     test "#save" do
       queue = FileTaskQueue.restore_if_exist(temp_queue_path)
       assert_false queue.queued?
-      queue.enq JobTask.new('test_dummy_job_task')
+      queue.enqueue JobTask.deserialize('subsys/test_dummy_job_task')
       queue.save
       assert_true  queue.queued?
     end
@@ -66,8 +65,8 @@ module Bricolage
     test "DatabaseTaskQueue.restore_if_exist" do
       queue1 = DatabaseTaskQueue.restore_if_exist(context, jobnet)
       assert_equal 0, queue1.size
-      queue1.enq jobtask1
-      queue1.enq jobtask2
+      queue1.enqueue jobtask1
+      queue1.enqueue jobtask2
       queue1.dequeuing
       queue2 = DatabaseTaskQueue.restore_if_exist(context, jobnet)
       assert_equal 2, queue2.size
@@ -76,13 +75,13 @@ module Bricolage
     test "#save" do
       queue = DatabaseTaskQueue.restore_if_exist(context, jobnet)
       assert_false queue.queued?
-      queue.enq jobtask1
+      queue.enqueue jobtask1
       assert_true  queue.queued?
     end
 
     test "#lock" do
       queue = DatabaseTaskQueue.restore_if_exist(context, jobnet)
-      queue.enq jobtask1
+      queue.enqueue jobtask1
       assert_false queue.locked?
       queue.lock
       assert_true  queue.locked?
@@ -90,7 +89,7 @@ module Bricolage
 
     test "#unlock" do
       queue = DatabaseTaskQueue.restore_if_exist(context, jobnet)
-      queue.enq jobtask1
+      queue.enqueue jobtask1
       queue.lock
       assert_true  queue.locked?
       queue.unlock

--- a/test/test_taskqueue.rb
+++ b/test/test_taskqueue.rb
@@ -68,8 +68,7 @@ module Bricolage
       assert_equal 0, queue1.size
       queue1.enq jobtask1
       queue1.enq jobtask2
-      queue1.save
-
+      queue1.dequeuing
       queue2 = DatabaseTaskQueue.restore_if_exist(context, jobnet)
       assert_equal 2, queue2.size
     end
@@ -78,14 +77,12 @@ module Bricolage
       queue = DatabaseTaskQueue.restore_if_exist(context, jobnet)
       assert_false queue.queued?
       queue.enq jobtask1
-      queue.save
       assert_true  queue.queued?
     end
 
     test "#lock" do
       queue = DatabaseTaskQueue.restore_if_exist(context, jobnet)
       queue.enq jobtask1
-      queue.save
       assert_false queue.locked?
       queue.lock
       assert_true  queue.locked?
@@ -94,7 +91,6 @@ module Bricolage
     test "#unlock" do
       queue = DatabaseTaskQueue.restore_if_exist(context, jobnet)
       queue.enq jobtask1
-      queue.save
       queue.lock
       assert_true  queue.locked?
       queue.unlock


### PR DESCRIPTION
bricolageのqueueを実行環境のローカルファイルとして管理する方法とは別に、専用データベースを使って管理する方法を追加します。

一度方針を確認していただくためにDraft PR化しておきます。まだWIPです。

## 各コミット内容
3900866 PostgreSQLにridgepoleで必要なテーブル用意する
6b62a8b TaskQueue用のテストを用意しつつ、DatabaseTaskQueueを追加する

## ToDo
1. testが通るように修正する
2. 生SQLを触っているのをなんとかする
    - Job, JobNet, JobExecution, JobExecutionState classをそれぞれ作るはず
3. 実行からの流れに手を加える
    - optionの付け方とかデフォルトがDB or Fileなのかとか

## 考え中
設計時に`*.LOCK` のことを忘れていた。`lock`/`unlock`を`job_executions/status`で表現して他の状態を示すものをmessageに書こうか、lock用カラムを追加するか
（今のところは前者で書いているが、後者のほうが良さそうに感じる）

