### PR TITLE
Change priority of variable from command v option

### DIFF
--- a/lib/bricolage/application.rb
+++ b/lib/bricolage/application.rb
@@ -39,7 +39,7 @@ module Bricolage
       @hooks.run_before_option_parsing_hooks(opts)
       opts.parse!(ARGV)
 
-      @ctx = Context.for_application(opts.home, opts.job_file, environment: opts.environment, global_variables: opts.global_variables)
+      @ctx = Context.for_application(opts.home, opts.job_file, environment: opts.environment, option_variables: opts.option_variables)
       opts.merge_saved_options(@ctx.load_system_options)
 
       if opts.dump_options?
@@ -294,7 +294,7 @@ module Bricolage
       @job_file = nil
       @environment = nil
       @home = nil
-      @global_variables = Variables.new
+      @option_variables = Variables.new
       @dry_run = false
       @explain = false
       @list_global_variables = false
@@ -351,9 +351,9 @@ Global Options:
       parser.on('-r', '--require=FEATURE', 'Requires ruby library.') {|feature|
         require feature
       }
-      parser.on('-v', '--variable=NAME=VALUE', 'Set global variable (is different from job-level -v !!).') {|name_value|
+      parser.on('-v', '--variable=NAME=VALUE', 'Set option variable (is different from job-level -v !!).') {|name_value|
         name, value = name_value.split('=', 2)
-        @global_variables[name] = value
+        @option_variables[name] = value
       }
       parser.on('--dump-options', 'Shows option parsing result and quit.') {
         @dump_options = true
@@ -401,7 +401,7 @@ Global Options:
       @dump_options
     end
 
-    attr_reader :global_variables
+    attr_reader :option_variables
 
     def list_global_variables?
       @list_global_variables

--- a/lib/bricolage/application.rb
+++ b/lib/bricolage/application.rb
@@ -351,7 +351,7 @@ Global Options:
       parser.on('-r', '--require=FEATURE', 'Requires ruby library.') {|feature|
         require feature
       }
-      parser.on('-v', '--variable=NAME=VALUE', 'Set option variable (is different from job-level -v !!).') {|name_value|
+      parser.on('-v', '--variable=NAME=VALUE', 'Set option variable.') {|name_value|
         name, value = name_value.split('=', 2)
         @option_variables[name] = value
       }

--- a/lib/bricolage/context.rb
+++ b/lib/bricolage/context.rb
@@ -19,7 +19,7 @@ module Bricolage
       FileSystem.home_path(opt_path)
     end
 
-    def Context.for_application(home_path = nil, job_path_0 = nil, job_path: nil, environment: nil, global_variables: nil, logger: nil)
+    def Context.for_application(home_path = nil, job_path_0 = nil, job_path: nil, environment: nil, option_variables: nil, logger: nil)
       env = environment(environment)
       if (job_path ||= job_path_0)
         fs = FileSystem.for_job_path(job_path, env)
@@ -29,21 +29,21 @@ module Bricolage
       else
         fs = FileSystem.for_options(home_path, env)
       end
-      load(fs, env, global_variables: global_variables, logger: logger)
+      load(fs, env, option_variables: option_variables, logger: logger)
     end
 
-    def Context.load(fs, env, global_variables: nil, data_sources: nil, logger: nil)
-      new(fs, env, global_variables: global_variables, logger: logger).tap {|ctx|
+    def Context.load(fs, env, option_variables: nil, data_sources: nil, logger: nil)
+      new(fs, env, option_variables: option_variables, logger: logger).tap {|ctx|
         ctx.load_configurations
       }
     end
     private_class_method :load
 
-    def initialize(fs, env, global_variables: nil, data_sources: nil, logger: nil)
+    def initialize(fs, env, option_variables: nil, data_sources: nil, logger: nil)
       @logger = logger || Logger.default
       @filesystem = fs
       @environment = env
-      @opt_global_variables = global_variables || Variables.new
+      @option_variables = option_variables || Variables.new
       @data_sources = data_sources
     end
 
@@ -56,6 +56,7 @@ module Bricolage
 
     attr_reader :environment
     attr_reader :logger
+    attr_reader :option_variables
 
     def get_data_source(type, name)
       @data_sources.get(type, name)
@@ -63,7 +64,7 @@ module Bricolage
 
     def subsystem(id)
       self.class.new(@filesystem.subsystem(id), @environment,
-        global_variables: @opt_global_variables,
+        option_variables: @option_variables,
         data_sources: @data_sources,
         logger: @logger)
     end
@@ -102,7 +103,6 @@ module Bricolage
       Variables.union(
         builtin_variables,
         load_global_variables,
-        @opt_global_variables
       )
     end
 

--- a/lib/bricolage/job.rb
+++ b/lib/bricolage/job.rb
@@ -41,6 +41,7 @@ module Bricolage
       @job_class = job_class
       @context = context
       @global_variables = nil
+      @option_variables = @context.option_variables
       @param_decls = @job_class.get_parameters
       @param_vals = nil      # Parameters::IntermediateValues by *.job
       @param_vals_opt = nil  # Parameters::IntermediateValues by options
@@ -87,6 +88,7 @@ module Bricolage
 
       job_file_rest_vars = @param_vals ? @param_vals.variables : Variables.new
       job_v_opt_vars = @param_vals_opt ? @param_vals_opt.variables : Variables.new
+      option_vars = @option_variables ? @option_variables : Variables.new
 
       # We use different variable set for paramter expansion and
       # SQL variable expansion.  Parameter expansion uses global
@@ -107,6 +109,7 @@ module Bricolage
         @global_variables,
         @params.variables,   # Like $dest_table
         job_file_rest_vars,
+        option_vars,
         job_v_opt_vars
         #          v High precedence
       )

--- a/lib/bricolage/job.rb
+++ b/lib/bricolage/job.rb
@@ -106,12 +106,12 @@ module Bricolage
       # Then, expand SQL variables and check with declarations.
       vars = Variables.union(
         #          ^ Low precedence
-        declarations.default_variables, # defined by jobclass
+        declarations.default_variables, # default value written in *.sql
         @global_variables,   # from yaml file
         @params.variables,   # Like $dest_table in job file
         job_file_rest_vars,  # custom variable at header of job file
-        cmd_v_opt_vars,      # -v option for jobnet command
-        job_v_opt_vars       # -v option for job command
+        cmd_v_opt_vars,      # -v option for bricolage/bricolage-jobnet command
+        job_v_opt_vars       # -v option for bricolage command using jobclass
         #          v High precedence
       )
       @variables = vars.resolve

--- a/lib/bricolage/job.rb
+++ b/lib/bricolage/job.rb
@@ -88,7 +88,7 @@ module Bricolage
 
       job_file_rest_vars = @param_vals ? @param_vals.variables : Variables.new
       job_v_opt_vars = @param_vals_opt ? @param_vals_opt.variables : Variables.new
-      option_vars = @option_variables ? @option_variables : Variables.new
+      cmd_v_opt_vars = @option_variables ? @option_variables : Variables.new
 
       # We use different variable set for paramter expansion and
       # SQL variable expansion.  Parameter expansion uses global
@@ -96,6 +96,7 @@ module Bricolage
       base_vars = Variables.union(
         #          ^ Low precedence
         @global_variables,
+        cmd_v_opt_vars,
         job_v_opt_vars
         #          v High precedence
       )
@@ -105,12 +106,12 @@ module Bricolage
       # Then, expand SQL variables and check with declarations.
       vars = Variables.union(
         #          ^ Low precedence
-        declarations.default_variables,
-        @global_variables,
-        @params.variables,   # Like $dest_table
-        job_file_rest_vars,
-        option_vars,
-        job_v_opt_vars
+        declarations.default_variables, # defined by jobclass
+        @global_variables,   # from yaml file
+        @params.variables,   # Like $dest_table in job file
+        job_file_rest_vars,  # custom variable at header of job file
+        cmd_v_opt_vars,      # -v option for jobnet command
+        job_v_opt_vars       # -v option for job command
         #          v High precedence
       )
       @variables = vars.resolve

--- a/lib/bricolage/jobnetrunner.rb
+++ b/lib/bricolage/jobnetrunner.rb
@@ -39,7 +39,7 @@ module Bricolage
       @hooks.run_before_option_parsing_hooks(opts)
       opts.parse!(ARGV)
 
-      @ctx = Context.for_application(job_path: opts.jobnet_files.first, environment: opts.environment, global_variables: opts.global_variables)
+      @ctx = Context.for_application(job_path: opts.jobnet_files.first, environment: opts.environment, option_variables: opts.option_variables)
       opts.merge_saved_options(@ctx.load_system_options)
 
       jobnet = RootJobNet.load_auto(@ctx, opts.jobnet_files)
@@ -219,7 +219,7 @@ module Bricolage
       def initialize(app)
         @app = app
         @environment = nil
-        @global_variables = Variables.new
+        @option_variables = Variables.new
         @jobnet_files = nil
 
         @dump_options = false
@@ -295,9 +295,9 @@ Options:
         parser.on('-l', '--list-jobs', 'Lists target jobs without executing.') {
           @list_jobs = true
         }
-        parser.on('-v', '--variable=NAME=VALUE', 'Defines global variable.') {|name_value|
+        parser.on('-v', '--variable=NAME=VALUE', 'Defines option variable.') {|name_value|
           name, value = name_value.split('=', 2)
-          @global_variables[name] = value
+          @option_variables[name] = value
         }
         parser.on('--dump-options', 'Shows option parsing result and quit.') {
           @dump_options = true
@@ -329,7 +329,7 @@ Options:
 
       attr_reader :jobnet_files
 
-      attr_reader :global_variables
+      attr_reader :option_variables
 
       def dump_options?
         @dump_options

--- a/test/test_variables.rb
+++ b/test/test_variables.rb
@@ -23,7 +23,7 @@ module Bricolage
       ctx = DummyContextForGvarTest.new(fs, 'development')
       ctx.builtin_variables = Variables.define {|vars|
         # global variables from builtin
-        vars.add Variable.new('builltin_variable', 'loc_builtin_value')
+        vars.add Variable.new('builtin_variable', 'loc_builtin_value')
         vars.add Variable.new('ow_yml_variable', 'loc_builtin_value')
       }
       ctx.variable_yml_vars = Variables.define {|vars|

--- a/test/test_variables.rb
+++ b/test/test_variables.rb
@@ -18,18 +18,18 @@ module Bricolage
       opt_gvars = Variables.new
       opt_gvars.add Variable.new('var_global_opt', 'loc_global_opt')
       fs = DummyFS.new('/home/path')
-      ctx = DummyContextForGvarTest.new(fs, 'development', global_variables: opt_gvars)
+      ctx = DummyContextForGvarTest.new(fs, 'development', option_variables: opt_gvars)
       ctx.variable_yml_vars = Variables.define {|vars|
         vars.add Variable.new('var_variable_yml', 'loc_variable_yml')
         vars.add Variable.new('var_global_opt', 'loc_variable_yml')
       }
       result = ctx.global_variables
-
       assert_equal 'loc_variable_yml', result['var_variable_yml']
-      assert_equal 'loc_global_opt', result['var_global_opt']
+      assert_equal 'loc_variable_yml', result['var_global_opt']
+
     end
 
-    DummyContext = Struct.new(:global_variables)
+    DummyContext = Struct.new(:global_variables, :option_variables)
     class DummyContext
       def job_dir
         '/job/dir'

--- a/test/test_variables.rb
+++ b/test/test_variables.rb
@@ -10,23 +10,30 @@ module Bricolage
   class TestVaribles < Test::Unit::TestCase
     DummyFS = Struct.new(:home_path)
     class DummyContextForGvarTest < Context
-      attr_accessor :variable_yml_vars
+      attr_accessor :variable_yml_vars, :builtin_variables
       alias load_global_variables variable_yml_vars
+
+      def job_dir
+        '/job/dir'
+      end
     end
 
     test "global variable precedence" do
-      opt_gvars = Variables.new
-      opt_gvars.add Variable.new('var_global_opt', 'loc_global_opt')
       fs = DummyFS.new('/home/path')
-      ctx = DummyContextForGvarTest.new(fs, 'development', option_variables: opt_gvars)
+      ctx = DummyContextForGvarTest.new(fs, 'development')
+      ctx.builtin_variables = Variables.define {|vars|
+        # global variables from builtin
+        vars.add Variable.new('builltin_variable', 'loc_builtin_value')
+        vars.add Variable.new('ow_yml_variable', 'loc_builtin_value')
+      }
       ctx.variable_yml_vars = Variables.define {|vars|
-        vars.add Variable.new('var_variable_yml', 'loc_variable_yml')
-        vars.add Variable.new('var_global_opt', 'loc_variable_yml')
+        # global variables from yaml file
+        vars.add Variable.new('ow_yml_variable', 'loc_yml_value')
       }
       result = ctx.global_variables
-      assert_equal 'loc_variable_yml', result['var_variable_yml']
-      assert_equal 'loc_variable_yml', result['var_global_opt']
 
+      assert_equal 'loc_builtin_value', result['builltin_variable']
+      assert_equal 'loc_yml_value', result['ow_yml_variable'] # overwritten
     end
 
     DummyContext = Struct.new(:global_variables, :option_variables)
@@ -60,28 +67,67 @@ module Bricolage
     end
 
     test "variable precedence (*.job)" do
+      # global variables
       gvars = Variables.new
-      gvars.add Variable.new('ow_global_variable', 'loc_global_variable')
-      gvars.add Variable.new('ow_rest_var', 'loc_global_variable')
-      gvars.add Variable.new('ow_job_opt', 'loc_global_variable')
+      gvars.add Variable.new('global_variable', 'loc_global_value')
+      gvars.add Variable.new('ow_rest_variable', 'loc_global_value')
+      gvars.add Variable.new('ow_job_option_variable', 'loc_global_value')
+
       ctx = DummyContext.new(gvars)
       job_class = DummyJobClass.new
       job = Job.new('varprec', job_class, ctx)
       job.init_global_variables
       job.bind_parameters({
-        'ow_rest_var' => 'loc_rest_var',
-        'ow_job_opt' => 'loc_rest_var'
+        # custom variable at header of job file
+        'ow_rest_variable' => 'loc_rest_value',
+        'ow_job_option_variable' => 'loc_rest_value'
       })
       job.parsing_options {|h|
         opts = OptionParser.new
         h.define_options(opts)
-        opts.parse!(['-v', 'ow_job_opt=loc_job_opt'])
+        # -v option variable for job command
+        opts.parse!(['-v', 'ow_job_option_variable=loc_job_option_value'])
       }
       job.compile
 
-      assert_equal 'loc_global_variable', job.variables['ow_global_variable']
-      assert_equal 'loc_rest_var', job.variables['ow_rest_var']
-      assert_equal 'loc_job_opt', job.variables['ow_job_opt']
+      assert_equal 'loc_global_value', job.variables['global_variable']
+      assert_equal 'loc_rest_value', job.variables['ow_rest_variable'] # overwritten
+      assert_equal 'loc_job_option_value', job.variables['ow_job_option_variable'] # overwritten
+    end
+
+    test "variable precedence (*.jobnet)" do
+      # -v option variable for jobnet command
+      ovars = Variables.new
+      ovars.add Variable.new('ow_jobnet_option_variable', 'loc_option_value')
+
+      fs = DummyFS.new('/home/path')
+      ctx = DummyContextForGvarTest.new(fs, 'development', option_variables: ovars)
+      ctx.builtin_variables = Variables.define {|vars|
+        # global variables from builtin
+        vars.add Variable.new('ow_global_variable', 'BUILTIN_VALUE')
+        vars.add Variable.new('ow_rest_variable', 'BUILTIN_VALUE')
+        vars.add Variable.new('ow_jobnet_option_variable', 'BUILTIN_VALUE')
+      }
+      ctx.variable_yml_vars = Variables.define {|vars|
+        # global variables from yaml file
+        vars.add Variable.new('ow_global_variable', 'loc_yml_value')
+        vars.add Variable.new('ow_rest_variable', 'loc_yml_value')
+        vars.add Variable.new('ow_jobnet_option_variable', 'loc_yml_value')
+      }
+
+      job_class = DummyJobClass.new
+      job = Job.new('varprec', job_class, ctx)
+      job.init_global_variables
+      job.bind_parameters({
+        # custom variable at header of job file
+        'ow_rest_variable' => 'loc_rest_value',
+        'ow_jobnet_option_variable' => 'loc_rest_value',
+      })
+      job.compile
+
+      assert_equal 'loc_yml_value', job.variables['ow_global_variable']
+      assert_equal 'loc_rest_value', job.variables['ow_rest_variable'] # overwritten
+      assert_equal 'loc_option_value', job.variables['ow_jobnet_option_variable'] # overwritten
     end
 
     test "lazy reference resolution" do

--- a/test/test_variables.rb
+++ b/test/test_variables.rb
@@ -32,7 +32,7 @@ module Bricolage
       }
       result = ctx.global_variables
 
-      assert_equal 'loc_builtin_value', result['builltin_variable']
+      assert_equal 'loc_builtin_value', result['builtin_variable']
       assert_equal 'loc_yml_value', result['ow_yml_variable'] # overwritten
     end
 


### PR DESCRIPTION
https://github.com/bricolages/bricolage/issues/115 対応です
`-v` オプションで入れる変数を使ってjobnet内jobの`src-table` などを書き換えられるようにします

bricolage内部で数種類存在する変数の種類を一つ増やし、`option_variables` を追加します。
今まで `global_variables` として渡っていた -v オプションの変数指定を `option_variables` に変え、 `@global_variables` はそのままにして、優先順位の上位に追加した変数を加えます。

ローカルでjobnetを実行し、jobnet内にあるjobのsrc-tableで指定している変数書き換えができてることは確認しました