### PR TITLE
Bump version to 6.0.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,11 @@
 # Bricolage Release Note
 
+## version 6.0.0
+
+- [new] taskqueue supports to use PotgresSQL DB.
+- [new] add retry for postgresql connection.
+- [new] change priority of variable from command -v option.
+
 ## version 5.30.0
 
 - [new] streaming_load: new option --ctl-ds to change S3 data source for metadata files.

--- a/lib/bricolage/version.rb
+++ b/lib/bricolage/version.rb
@@ -1,4 +1,4 @@
 module Bricolage
   APPLICATION_NAME = 'Bricolage'
-  VERSION = '5.30.0'
+  VERSION = '6.0.0'
 end


### PR DESCRIPTION
色々機能追加を行ったのでBricolage メジャーバージョン をあげます