### PR TITLE
Add Dockerfile and Gemfile.lock for build docker image to migrate DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ doc/
 /dev
 /test/home/config
 Gemfile.lock
+!schema/Gemifle.lock

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,4 @@ doc/
 
 /dev
 /test/home/config
-Gemfile.lock
-!schema/Gemifle.lock
+/Gemfile.lock

--- a/schema/Dockerfile
+++ b/schema/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:2.6.5-stretch
+
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev libpq5 postgresql-client
+
+COPY ./Gemfile /tmp/Gemfile
+COPY ./Gemfile.lock /tmp/Gemfile.lock
+RUN cd /tmp && bundle install -j4 --deployment --without 'development test'
+
+WORKDIR /app
+COPY . /app
+RUN cp -a /tmp/vendor /app/
+
+CMD ["bundle", "exec", "ridgepole", "-f", "Schemafile", "-c", "database.yml", "--merge", "--dry-run"]d
+

--- a/schema/Dockerfile
+++ b/schema/Dockerfile
@@ -10,5 +10,4 @@ WORKDIR /app
 COPY . /app
 RUN cp -a /tmp/vendor /app/
 
-CMD ["bundle", "exec", "ridgepole", "-f", "Schemafile", "-c", "database.yml", "--merge", "--dry-run"]d
-
+CMD ["bundle", "exec", "ridgepole", "-f", "Schemafile", "-c", "database.yml", "--merge", "--dry-run"]

--- a/schema/Gemfile.lock
+++ b/schema/Gemfile.lock
@@ -1,0 +1,37 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (5.2.3)
+      activesupport (= 5.2.3)
+    activerecord (5.2.3)
+      activemodel (= 5.2.3)
+      activesupport (= 5.2.3)
+      arel (>= 9.0)
+    activesupport (5.2.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    arel (9.0.0)
+    concurrent-ruby (1.1.5)
+    diffy (3.3.0)
+    i18n (1.6.0)
+      concurrent-ruby (~> 1.0)
+    minitest (5.11.3)
+    pg (1.1.4)
+    ridgepole (0.7.7)
+      activerecord (>= 5.0.1, < 6)
+      diffy
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  pg
+  ridgepole
+
+BUNDLED WITH
+   1.17.2


### PR DESCRIPTION
開発環境でridgepoleをするために用意していた `/schema` 以下を、本番DBにも適用できるようにするため、Dockerfile（とGemfile.lock）を追加します。