### PR TITLE
Replace DAO connection to one shared connection from three separated connections

### DIFF
--- a/lib/bricolage/dao/job.rb
+++ b/lib/bricolage/dao/job.rb
@@ -8,7 +8,7 @@ module Bricolage
 
       def initialize(datasource)
         @datasource = datasource
-        @conn = @datasource.open
+        @conn = @datasource.open_shared_connection
       end
 
       def find(subsystem, job_name, jobnet_id)

--- a/lib/bricolage/dao/jobexecution.rb
+++ b/lib/bricolage/dao/jobexecution.rb
@@ -20,10 +20,6 @@ module Bricolage
         @datasource = datasource
       end
 
-      def connection_close
-        @datasource.close_shared_connection
-      end
-
       def where(**args)
         where_clause = compile_where_expr(args)
 

--- a/lib/bricolage/dao/jobexecution.rb
+++ b/lib/bricolage/dao/jobexecution.rb
@@ -18,31 +18,28 @@ module Bricolage
 
       def initialize(datasource)
         @datasource = datasource
-        @conn = @datasource.open_shared_connection
       end
 
       def connection_close
-        @conn.close
-      end
-
-      def connection_reopen
-        @conn = @datasource.open_shared_connection
+        @datasource.close_shared_connection
       end
 
       def where(**args)
         where_clause = compile_where_expr(args)
 
-        job_executions = @conn.query_rows(<<~SQL)
-          select
-              *
-          from
-              job_executions je
-              join jobs j using(job_id)
-              join jobnets jn using(jobnet_id, "subsystem")
-          where
-              #{where_clause}
-          ;
-        SQL
+        job_executions = @datasource.open_shared_connection do |conn|
+          conn.query_rows(<<~SQL)
+            select
+                *
+            from
+                job_executions je
+                join jobs j using(job_id)
+                join jobnets jn using(jobnet_id, "subsystem")
+            where
+                #{where_clause}
+            ;
+          SQL
+        end
 
         if job_executions.empty?
           []
@@ -56,21 +53,23 @@ module Bricolage
         set_clause = set.map{|k,v| "#{k} = #{convert_value(v)}"}.join(', ')
 
         where_clause = compile_where_expr(where)
-        job_executions = @conn.execute_update(<<~SQL)
-          update job_executions je
-          set #{set_clause}
-          from
-              jobs j
-              join jobnets jn using(jobnet_id, "subsystem")
-          where
-              je.job_id = j.job_id
-              and #{where_clause}
-          returning *
-          ;
-        SQL
+        job_executions = @datasource.open_shared_connection do |conn|
+          conn.execute_update(<<~SQL)
+            update job_executions je
+            set #{set_clause}
+            from
+                jobs j
+                join jobnets jn using(jobnet_id, "subsystem")
+            where
+                je.job_id = j.job_id
+                and #{where_clause}
+            returning *
+            ;
+          SQL
+        end
 
         job_executions = JobExecution.for_record(job_executions)
-        JobExecutionState.job_executions_change(@conn, job_executions)
+        JobExecutionState.job_executions_change(@datasource, job_executions)
         job_executions
       end
 
@@ -78,16 +77,18 @@ module Bricolage
         set_columns, set_values = compile_set_expr(set)
         set_clause = set.map{|k,v| "#{k} = #{convert_value(v)}"}.join(', ')
 
-        job_executions = @conn.query_rows(<<~SQL)
-          insert into job_executions (#{set_columns})
-              values (#{set_values})
-              on conflict (job_id)
-              do update set #{set_clause}
-          ;
-        SQL
+        job_executions = @datasource.open_shared_connection do |conn|
+          conn.query_rows(<<~SQL)
+            insert into job_executions (#{set_columns})
+                values (#{set_values})
+                on conflict (job_id)
+                do update set #{set_clause}
+            ;
+          SQL
+        end
 
         job_executions = JobExecution.for_record(job_executions)
-        JobExecutionState.job_executions_change(@conn, job_executions)
+        JobExecutionState.job_executions_change(@datasource, job_executions)
         job_executions
       end
 
@@ -135,16 +136,14 @@ module Bricolage
           raise "invalid type for 'cond' argument in JobExecution#convert_cond: #{cond} is #{cond.class}"
         end
       end
-
-
     end
 
     class JobExecutionState
 
       include SQLUtils
 
-      def self.job_executions_change(connection, job_executions)
-        state = new(connection)
+      def self.job_executions_change(datasource, job_executions)
+        state = new(datasource)
         job_executions.each do |je|
           state.create(
             job_execution_id: je.job_execution_id,
@@ -155,14 +154,16 @@ module Bricolage
         end
       end
 
-      def initialize(connection)
-        @conn = connection
+      def initialize(datasource)
+        @datasource = datasource
       end
 
       def create(job_execution_id:, status:, message:, job_id:)
         columns = 'job_execution_id, status, message, created_at, job_id'
         values = "#{job_execution_id}, #{s(status)}, #{s(message)}, now(), #{job_id}"
-        @conn.execute("insert into job_execution_states (#{columns}) values (#{values});")
+        @datasource.open_shared_connection do |conn|
+          conn.execute("insert into job_execution_states (#{columns}) values (#{values});")
+        end
       end
     end
   end

--- a/lib/bricolage/dao/jobexecution.rb
+++ b/lib/bricolage/dao/jobexecution.rb
@@ -18,7 +18,7 @@ module Bricolage
 
       def initialize(datasource)
         @datasource = datasource
-        @conn = @datasource.open
+        @conn = @datasource.open_shared_connection
       end
 
       def connection_close
@@ -26,7 +26,7 @@ module Bricolage
       end
 
       def connection_reopen
-        @conn = @datasource.open
+        @conn = @datasource.open_shared_connection
       end
 
       def where(**args)
@@ -163,9 +163,6 @@ module Bricolage
         columns = 'job_execution_id, status, message, created_at, job_id'
         values = "#{job_execution_id}, #{s(status)}, #{s(message)}, now(), #{job_id}"
         @conn.execute("insert into job_execution_states (#{columns}) values (#{values});")
-      rescue
-        require 'pry'
-        binding.pry
       end
     end
   end

--- a/lib/bricolage/dao/jobnet.rb
+++ b/lib/bricolage/dao/jobnet.rb
@@ -8,7 +8,7 @@ module Bricolage
 
       def initialize(datasource)
         @datasource = datasource
-        @conn = @datasource.open
+        @conn = @datasource.open_shared_connection
       end
 
       def find(subsystem, jobnet_name)

--- a/lib/bricolage/dao/jobnet.rb
+++ b/lib/bricolage/dao/jobnet.rb
@@ -8,22 +8,23 @@ module Bricolage
 
       def initialize(datasource)
         @datasource = datasource
-        @conn = @datasource.open_shared_connection
       end
 
       def find(subsystem, jobnet_name)
-        jobnet = @conn.query_row(<<~SQL)
-          select
-              jobnet_id
-              , "subsystem"
-              , jobnet_name
-          from
-              jobnets
-          where
-              "subsystem" = #{s(subsystem)}
-              and jobnet_name = #{s(jobnet_name)}
-          ;
-        SQL
+        jobnet = @datasource.open_shared_connection do |conn|
+          conn.query_row(<<~SQL)
+            select
+                jobnet_id
+                , "subsystem"
+                , jobnet_name
+            from
+                jobnets
+            where
+                "subsystem" = #{s(subsystem)}
+                and jobnet_name = #{s(jobnet_name)}
+            ;
+          SQL
+        end
 
         if jobnet.nil?
           nil
@@ -33,12 +34,14 @@ module Bricolage
       end
 
       def create(subsystem, jobnet_name)
-        jobnet = @conn.query_row(<<~SQL)
-          insert into jobnets ("subsystem", jobnet_name)
-              values (#{s(subsystem)}, #{s(jobnet_name)})
-              returning jobnet_id, "subsystem", jobnet_name
-          ;
-        SQL
+        jobnet = @datasource.open_shared_connection do |conn|
+          conn.query_row(<<~SQL)
+            insert into jobnets ("subsystem", jobnet_name)
+                values (#{s(subsystem)}, #{s(jobnet_name)})
+                returning jobnet_id, "subsystem", jobnet_name
+            ;
+          SQL
+        end
 
         Attributes.new(jobnet['jobnet_id'], jobnet['subsystem'], jobnet['jobnet_name'])
       end

--- a/lib/bricolage/psqldatasource.rb
+++ b/lib/bricolage/psqldatasource.rb
@@ -141,6 +141,7 @@ module Bricolage
           conn = @connection_pool.shift
           conn.execute_query('select 1'){}
         rescue
+          conn.close
           conn = open
         end
       end

--- a/lib/bricolage/psqldatasource.rb
+++ b/lib/bricolage/psqldatasource.rb
@@ -131,15 +131,16 @@ module Bricolage
       end
     end
 
-    def open_shared_connection(&block)
+    def open_shared_connection
       raise ParameterError, 'open_shared_connection require block' unless block_given?
-      conn = @connection_pool.empty? ? open : @connection_pool.pop
+      conn = @connection_pool.empty? ? open : @connection_pool.shift
+      conn.execute_query('select 1'){}
       yield conn
     ensure
       @connection_pool.push(conn)
     end
 
-    def close_shared_connection
+    def clear_connection_pool
       @connection_pool.map(&:close)
       @connection_pool = []
     end

--- a/lib/bricolage/psqldatasource.rb
+++ b/lib/bricolage/psqldatasource.rb
@@ -130,6 +130,16 @@ module Bricolage
       end
     end
 
+    def open_shared_connection(&block)
+      @conn ||= open
+
+      if block_given?
+        yield @conn
+      else
+        return @conn
+      end
+    end
+
     def query_batch(query, batch_size = 5000, &block)
       open {|conn| conn.query_batch(query, batch_size, &block) }
     end

--- a/lib/bricolage/taskqueue.rb
+++ b/lib/bricolage/taskqueue.rb
@@ -176,7 +176,6 @@ module Bricolage
 
         @jobexecution_dao.connection_close
         task_result = yield task # running execute_job
-        @jobexecution_dao.connection_reopen
 
         if task_result.success?
           dequeued

--- a/lib/bricolage/taskqueue.rb
+++ b/lib/bricolage/taskqueue.rb
@@ -174,7 +174,7 @@ module Bricolage
       while task = self.next
         dequeuing
 
-        @jobexecution_dao.connection_close
+        @ds.clear_connection_pool
         task_result = yield task # running execute_job
 
         if task_result.success?


### PR DESCRIPTION
DAOのために用意した `DAO::Job` `DAO::JobNet` `DAO::JobExecution` がそれぞれ個別に `PostgresConnection` を開いていました。

できうる限りbricolage DBとのコネクションを同じものを使い回せるように、同一のdatasourceから張るコネクションを一本に共通化するメソッドを追加し、そちらでコネクションを張るようにしました。
DAOからbricolage DBに接続する際はすべてこの `open_shared_connection` を利用するようにします。