### PR TITLE
Modify jobe_execution_states table to add lock column

### DIFF
--- a/lib/bricolage/dao/jobexecution.rb
+++ b/lib/bricolage/dao/jobexecution.rb
@@ -150,6 +150,7 @@ module Bricolage
             job_execution_id: je.job_execution_id,
             status: je.status || '',
             message: je.message || '',
+            lock: locked?(je),
             job_id: je.job_id
           )
         end
@@ -159,13 +160,16 @@ module Bricolage
         @conn = connection
       end
 
-      def create(job_execution_id:, status:, message:, job_id:)
-        columns = 'job_execution_id, status, message, created_at, job_id'
-        values = "#{job_execution_id}, #{s(status)}, #{s(message)}, now(), #{job_id}"
+      def create(job_execution_id:, status:, message:, lock:, job_id:)
+        columns = 'job_execution_id, status, message, lock, created_at, job_id'
+        values = "#{job_execution_id}, #{s(status)}, #{s(message)}, #{lock}, now(), #{job_id}"
         @conn.execute("insert into job_execution_states (#{columns}) values (#{values});")
-      rescue
-        require 'pry'
-        binding.pry
+      end
+
+      private
+
+      def locked?(job_execution)
+        job_execution.lock == 't'
       end
     end
   end

--- a/schema/Schemafile
+++ b/schema/Schemafile
@@ -26,6 +26,7 @@ end
 create_table "job_execution_states", primary_key: "job_execution_state_id", force: :cascade do |t|
   t.integer  "job_execution_id", null: false
   t.string   "status",           null: false
+  t.boolean  "lock",             null: false
   t.string   "message"
   t.datetime "created_at", default: -> { "now()" }, null: false
   t.integer  "job_id",           null: false


### PR DESCRIPTION
`job_execution_states` テーブルに `lock` 情報が入っていないため、ロックをとったり外したりしたときの履歴がきちんと残らず2重に履歴レコードが発行されているように見えていました。

`job_execution_states` に `lock` カラムを追加し、 `JobExecutionState#create` にも `lock` 引数を追加します。
また、そのまま `JobExecution#for_record` 由来の `job_execution.lock` をみると `'t'` や `'f'` といったようにstringで保存されてしまっているのでboolに直します。