### PR TITLE
Replace lock system strategy  to use executor info

### DIFF
--- a/lib/bricolage/dao/job.rb
+++ b/lib/bricolage/dao/job.rb
@@ -4,7 +4,15 @@ module Bricolage
 
       include SQLUtils
 
-      Attributes = Struct.new(:id, :subsystem, :job_name, :jobnet_id)
+      Attributes = Struct.new(:id, :subsystem, :job_name, :jobnet_id, :executor_id)
+
+      def Job.for_record(job)
+        Attributes.new(*job.values)
+      end
+
+      def Job.for_records(jobs)
+        jobs.map { |job| Job.for_record(job) }
+      end
 
       def initialize(datasource)
         @datasource = datasource
@@ -31,7 +39,7 @@ module Bricolage
         if job.nil?
           nil
         else
-          Attributes.new(job['job_id'], job['subsystem'], job['job_name'], job['jobnet_id'])
+          Job.for_record(job)
         end
       end
 
@@ -45,7 +53,7 @@ module Bricolage
           SQL
         end
 
-        Attributes.new(job['job_id'], job['subsystem'], job['job_name'], job['jobnet_id'])
+        Job.for_record(job)
       end
 
       def find_or_create(subsystem, job_name, jobnet_id)

--- a/lib/bricolage/dao/jobexecution.rb
+++ b/lib/bricolage/dao/jobexecution.rb
@@ -30,7 +30,7 @@ module Bricolage
             from
                 job_executions je
                 join jobs j using(job_id)
-                join jobnets jn using(jobnet_id, "subsystem")
+                join jobnets jn using(jobnet_id)
             where
                 #{where_clause}
             ;
@@ -55,7 +55,7 @@ module Bricolage
             set #{set_clause}
             from
                 jobs j
-                join jobnets jn using(jobnet_id, "subsystem")
+                join jobnets jn using(jobnet_id)
             where
                 je.job_id = j.job_id
                 and #{where_clause}

--- a/lib/bricolage/dao/jobexecution.rb
+++ b/lib/bricolage/dao/jobexecution.rb
@@ -87,51 +87,6 @@ module Bricolage
         JobExecutionState.job_executions_change(@datasource, job_executions)
         job_executions
       end
-
-      private
-
-      def compile_set_expr(values_hash)
-        columns = values_hash.keys.map(&:to_s).join(', ')
-        values = values_hash.values.map{|v| convert_value(v) }.join(', ')
-        return columns, values
-      end
-
-      def convert_value(value)
-        if value == :now
-          'now()'
-        elsif value.nil?
-          "null"
-        elsif value == true or value == false
-          "#{value.to_s}"
-        elsif value.instance_of?(Integer) or value.instance_of?(Float)
-          "#{value.to_s}"
-        elsif value.instance_of?(String) or value.instance_of?(Pathname)
-          "#{s(value.to_s)}"
-        else
-          raise "invalid type for 'value' argument in JobExecution#convert_value: #{value} is #{value.class}"
-        end
-      end
-
-      def compile_where_expr(conds_hash)
-        conds_hash.map{|k,v| convert_cond(k,v) }.join(' and ')
-      end
-
-      def convert_cond(column, cond)
-        if cond.nil?
-          "#{column} is null"
-        elsif cond.instance_of?(Array) # not support subquery
-          in_clause = cond.map{|c| convert_cond(column, c)}.join(' or ')
-          "(#{in_clause})"
-        elsif cond == true or cond == false
-          "#{column} is #{cond.to_s}"
-        elsif cond.instance_of?(Integer) or cond.instance_of?(Float)
-          "#{column} = #{cond}"
-        elsif cond.instance_of?(String) or cond.instance_of?(Pathname)
-          "#{column} = #{s(cond.to_s)}"
-        else
-          raise "invalid type for 'cond' argument in JobExecution#convert_cond: #{cond} is #{cond.class}"
-        end
-      end
     end
 
     class JobExecutionState

--- a/lib/bricolage/dao/jobexecution.rb
+++ b/lib/bricolage/dao/jobexecution.rb
@@ -4,10 +4,10 @@ module Bricolage
 
       include  SQLUtils
 
-      Attributes = Struct.new(:jobnet_id, :subsystem, :job_id, :job_execution_id,
-                                :status, :message, :submitted_at, :lock,
-                                :started_at, :finished_at, :source, :job_name, :jobnet_name,
-                                keyword_init: true)
+      Attributes = Struct.new(:jobnet_id, :job_id, :job_execution_id, :status, :message,
+                              :submitted_at, :lock,:started_at, :finished_at, :source,
+                              :job_name, :jobnet_name, :executor_id, :subsystem,
+                              keyword_init: true)
 
       def JobExecution.for_record(job_executions)
         job_executions.map do |je|

--- a/lib/bricolage/dao/jobnet.rb
+++ b/lib/bricolage/dao/jobnet.rb
@@ -4,7 +4,15 @@ module Bricolage
 
       include SQLUtils
 
-      Attributes = Struct.new(:id, :subsystem, :jobnet_name)
+      Attributes = Struct.new(:id, :subsystem, :jobnet_name, :executor_id)
+
+      def JobNet.for_record(jobnet)
+        Attributes.new(*jobnet.values)
+      end
+
+      def JobNet.for_records(jobnets)
+        jobnets.map { |jobnet| JobNet.for_record(jobnet) }
+      end
 
       def initialize(datasource)
         @datasource = datasource
@@ -29,7 +37,7 @@ module Bricolage
         if jobnet.nil?
           nil
         else
-          Attributes.new(jobnet['jobnet_id'], jobnet['subsystem'], jobnet['jobnet_name'])
+          JobNet.for_record(jobnet)
         end
       end
 
@@ -43,7 +51,7 @@ module Bricolage
           SQL
         end
 
-        Attributes.new(jobnet['jobnet_id'], jobnet['subsystem'], jobnet['jobnet_name'])
+        JobNet.for_record(jobnet)
       end
 
       def find_or_create(subsystem, jobnet_name)

--- a/lib/bricolage/exception.rb
+++ b/lib/bricolage/exception.rb
@@ -30,6 +30,10 @@ module Bricolage
   # Aquiring lock takes too long (e.g. VACUUM lock)
   class LockTimeout < JobFailure; end
 
+  # The executing jobnet or job is already locked.
+  # You should wait to unlock by another job execution or force to unlock manually.
+  class DoubleLockError < JobFailure; end
+
   # S3 related exceptions
   class S3Exception < JobFailureByException; end
 

--- a/lib/bricolage/sqlutils.rb
+++ b/lib/bricolage/sqlutils.rb
@@ -24,6 +24,48 @@ module Bricolage
       time.strftime('%Y-%m-%d %H:%M:%S')
     end
 
+    def compile_set_expr(values_hash)
+      columns = values_hash.keys.map(&:to_s).join(', ')
+      values = values_hash.values.map{|v| convert_value(v) }.join(', ')
+      return columns, values
+    end
+
+    def convert_value(value)
+      if value == :now
+        'now()'
+      elsif value.nil?
+        "null"
+      elsif value == true or value == false
+        "#{value.to_s}"
+      elsif value.instance_of?(Integer) or value.instance_of?(Float)
+        "#{value.to_s}"
+      elsif value.instance_of?(String) or value.instance_of?(Pathname)
+        "#{s(value.to_s)}"
+      else
+        raise "invalid type for 'value' argument in JobExecution#convert_value: #{value} is #{value.class}"
+      end
+    end
+
+    def compile_where_expr(conds_hash)
+      conds_hash.map{|k,v| convert_cond(k,v) }.join(' and ')
+    end
+
+    def convert_cond(column, cond)
+      if cond.nil?
+        "#{column} is null"
+      elsif cond.instance_of?(Array) # not support subquery
+        in_clause = cond.map{|c| convert_cond(column, c)}.join(' or ')
+        "(#{in_clause})"
+      elsif cond == true or cond == false
+        "#{column} is #{cond.to_s}"
+      elsif cond.instance_of?(Integer) or cond.instance_of?(Float)
+        "#{column} = #{cond}"
+      elsif cond.instance_of?(String) or cond.instance_of?(Pathname)
+        "#{column} = #{s(cond.to_s)}"
+      else
+        raise "invalid type for 'cond' argument in JobExecution#convert_cond: #{cond} is #{cond.class}"
+      end
+    end
   end
 
 end

--- a/lib/bricolage/taskqueue.rb
+++ b/lib/bricolage/taskqueue.rb
@@ -265,7 +265,7 @@ module Bricolage
     end
 
     def unlock_help
-      "Jobs with these ID are locked: #{locked_jobs.map(&:id)}"
+      "update the job_id records to unlock from job tables: #{locked_jobs.map(&:id)}"
     end
 
     # for debug to test

--- a/lib/bricolage/taskqueue.rb
+++ b/lib/bricolage/taskqueue.rb
@@ -190,28 +190,28 @@ module Bricolage
     end
 
     def enqueue(task)
-      @jobexecution_dao.update(where: {subsystem: task.subsystem, job_name: task.job_name},
+      @jobexecution_dao.update(where: {'j.subsystem': task.subsystem, job_name: task.job_name},
                                set:   {status: 'waiting', message: nil, submitted_at: :now, started_at: nil, finished_at: nil})
       @queue.push task
     end
 
     def dequeuing
       task = @queue.first
-      @jobexecution_dao.update(where: {subsystem: task.subsystem, job_name: task.job_name},
+      @jobexecution_dao.update(where: {'j.subsystem': task.subsystem, job_name: task.job_name},
                                set:   {status: 'running', started_at: :now})
       task
     end
 
     def dequeued
       task = @queue.shift
-      @jobexecution_dao.update(where: {subsystem: task.subsystem, job_name: task.job_name},
+      @jobexecution_dao.update(where: {'j.subsystem': task.subsystem, job_name: task.job_name},
                                set:   {status: 'succeeded', finished_at: :now})
       task
     end
 
     def restore
-      job_executions = @jobexecution_dao.where(subsystem: @subsys,
-                                               jobnet_name: @jobnet_name,
+      job_executions = @jobexecution_dao.where('j.subsystem': @jobs.map(&:subsystem).uniq,
+                                               jobnet_name: @jobnet.jobnet_name,
                                                status: ['waiting', 'running', 'failed'])
 
       job_executions.each do |je|

--- a/schema/Schemafile
+++ b/schema/Schemafile
@@ -2,12 +2,14 @@ create_table "jobs", primary_key: "job_id", force: :cascade do |t|
   t.string  "subsystem", null: false
   t.string  "job_name",  null: false
   t.integer "jobnet_id"
+  t.string  "executor_id"
   t.index ["subsystem", "job_name", "jobnet_id"], name: "job_unique", unique: true, using: :btree
 end
 
 create_table "jobnets", primary_key: "jobnet_id", force: :cascade do |t|
   t.string "subsystem",   null: false
   t.string "jobnet_name", null: false
+  t.string "executor_id"
   t.index ["subsystem", "jobnet_name"], name: "jobnet_unique", unique: true, using: :btree
 end
 
@@ -16,7 +18,6 @@ create_table "job_executions", primary_key: "job_execution_id", force: :cascade 
   t.string   "message"
   t.datetime "submitted_at", default: -> { "now()" }, null: false
   t.integer  "job_id",       null: false
-  t.boolean  "lock", null: false
   t.datetime "started_at"
   t.datetime "finished_at"
   t.string   "source"

--- a/test/test_c_streaming_load.rb
+++ b/test/test_c_streaming_load.rb
@@ -5,7 +5,7 @@ Bricolage::JobClass.get('streaming_load')
 module Bricolage
   class TestStreamingLoadJobClass_S3Queue < Test::Unit::TestCase
     def test_compile_name_pattern
-      q = StreamingLoadJobClass::S3Queue.new(data_source: nil, queue_path: nil, ctl_prefix: nil, persistent_path: nil, file_name: nil, logger: nil)
+      q = StreamingLoadJobClass::S3Queue.new(data_source: nil, ctl_ds: nil, queue_path: nil, ctl_prefix: nil, persistent_path: nil, file_name: nil, logger: nil)
       re = q.compile_name_pattern("%*%Y%m%d-%H%M_%Q.gz")
       assert_equal /\A[^\/]*(?<year>\d{4})(?<month>\d{2})(?<day>\d{2})\-(?<hour>\d{2})(?<minute>\d{2})_(?<seq>\d+)\.gz\z/, re
     end

--- a/test/test_taskqueue.rb
+++ b/test/test_taskqueue.rb
@@ -103,10 +103,10 @@ module Bricolage
       queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
       assert_false  queue.locked?
 
-      queue.lock_job(job1.id)
+      queue.lock_job(jobtask1)
       assert_true  queue.locked?
 
-      queue.unlock_job(job1.id)
+      queue.unlock_job(jobtask1)
       assert_false queue.locked?
     end
   end

--- a/test/test_taskqueue.rb
+++ b/test/test_taskqueue.rb
@@ -52,48 +52,61 @@ module Bricolage
     context = Context.for_application(home_path='test/home')
     datasource = context.get_data_source('psql', 'test_db')
     jobnet_path = Pathname.new('test/home/subsys/net1.jobnet')
-    jobnet = RootJobNet.load_auto(context, [jobnet_path]).jobnets.first
-    jobrefs = jobnet.refs - [jobnet.start, *jobnet.net_refs, jobnet.end]
+    jobnet_ref = RootJobNet.load_auto(context, [jobnet_path]).jobnets.first
+    jobrefs = jobnet_ref.refs - [jobnet_ref.start, *jobnet_ref.net_refs, jobnet_ref.end]
+
     jobtask1 = JobTask.new(jobrefs.pop)
     jobtask2 = JobTask.new(jobrefs.pop)
 
+    job_dao = Bricolage::DAO::Job.new(datasource)
+    jobnet_dao = Bricolage::DAO::JobNet.new(datasource)
+    jobnet = jobnet_dao.find_or_create('subsys','net1')
+    job1 = job_dao.find_or_create('subsys', 'job1', jobnet.id)
+    job2 = job_dao.find_or_create('subsys', 'job2', jobnet.id)
+
     teardown do
-      queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet)
-      queue.unlock
+      queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
       queue.clear
     end
 
+    test "#enqueue/#dequeuing/#dequeued" do
+      queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
+      assert_equal 0, queue.size
+      queue.enqueue jobtask1
+      assert_equal 1, queue.size
+      queue.dequeuing
+      assert_equal 1, queue.size
+      queue.dequeued
+      assert_equal 0, queue.size
+    end
+
     test "DatabaseTaskQueue.restore_if_exist" do
-      queue1 = DatabaseTaskQueue.restore_if_exist(datasource, jobnet)
+      queue1 = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
       assert_equal 0, queue1.size
       queue1.enqueue jobtask1
       queue1.enqueue jobtask2
       queue1.dequeuing
-      queue2 = DatabaseTaskQueue.restore_if_exist(datasource, jobnet)
+      queue2 = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
       assert_equal 2, queue2.size
     end
 
-    test "#save" do
-      queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet)
-      assert_false queue.queued?
-      queue.enqueue jobtask1
-      assert_true  queue.queued?
-    end
-
-    test "#lock" do
-      queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet)
-      queue.enqueue jobtask1
+    test "#lock_jobnet/#unlock_jobnet" do
+      queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
+      assert_false  queue.locked?
+      queue.lock_jobnet
+      assert_true  queue.locked?
+      queue.unlock_jobnet
       assert_false queue.locked?
-      queue.lock
-      assert_true  queue.locked?
     end
 
-    test "#unlock" do
-      queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet)
-      queue.enqueue jobtask1
-      queue.lock
+    test "#lock_job/#unlock_job" do
+      queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
+      assert_false  queue.locked?
+
+      queue.lock_job(job1.id)
       assert_true  queue.locked?
-      queue.unlock
+
+      queue.unlock_job(job1.id)
       assert_false queue.locked?
     end
   end


### PR DESCRIPTION
https://github.com/bricolages/bricolage/pull/122 と https://github.com/bricolages/bricolage/pull/123 を出した後に話し合った結果、bricolageのlockに関して設計変更をすることになりました

- lockはジョブの実行ではなくjobsとjobnetsに対してとることにする
  - jobs / jobnets テーブルはカタログだけではなくlock状態管理にも使われるようになる
  - jobのロックとjobnetのロックが分かれる
- executor_id というジョブ実行者を区別するIDを用意し、埋まっているとlockということにする
  - executor_id は実行環境がECSだったときは task_idを、そうでなければホストネームのどちらかをPIDと組み合わせて作成する
- lockにより防ぎたいのは同一ジョブの重複実行である
  - 今までのタイミングでlock/unlockしていたのはjobnetのlock
  - ジョブの実行前後でjobのlock/unlockをする

