### PR TITLE
Separate job execution by each execution

### DIFF
--- a/lib/bricolage/dao/job.rb
+++ b/lib/bricolage/dao/job.rb
@@ -4,7 +4,15 @@ module Bricolage
 
       include SQLUtils
 
-      Attributes = Struct.new(:id, :subsystem, :job_name, :jobnet_id)
+      Attributes = Struct.new(:id, :subsystem, :job_name, :jobnet_id, :executor_id)
+
+      def Job.for_record(job)
+        Attributes.new(*job.values)
+      end
+
+      def Job.for_records(jobs)
+        jobs.map { |job| Job.for_record(job) }
+      end
 
       def initialize(datasource)
         @datasource = datasource
@@ -31,7 +39,7 @@ module Bricolage
         if job.nil?
           nil
         else
-          Attributes.new(job['job_id'], job['subsystem'], job['job_name'], job['jobnet_id'])
+          Job.for_record(job)
         end
       end
 
@@ -45,7 +53,7 @@ module Bricolage
           SQL
         end
 
-        Attributes.new(job['job_id'], job['subsystem'], job['job_name'], job['jobnet_id'])
+        Job.for_record(job)
       end
 
       def find_or_create(subsystem, job_name, jobnet_id)

--- a/lib/bricolage/dao/jobexecution.rb
+++ b/lib/bricolage/dao/jobexecution.rb
@@ -30,7 +30,7 @@ module Bricolage
             from
                 job_executions je
                 join jobs j using(job_id)
-                join jobnets jn using(jobnet_id, "subsystem")
+                join jobnets jn using(jobnet_id)
             where
                 #{where_clause}
             ;
@@ -55,7 +55,7 @@ module Bricolage
             set #{set_clause}
             from
                 jobs j
-                join jobnets jn using(jobnet_id, "subsystem")
+                join jobnets jn using(jobnet_id)
             where
                 je.job_id = j.job_id
                 and #{where_clause}

--- a/lib/bricolage/dao/jobexecution.rb
+++ b/lib/bricolage/dao/jobexecution.rb
@@ -4,16 +4,23 @@ module Bricolage
 
       include  SQLUtils
 
+      STATUS_WAIT    = 'waiting'.freeze
+      STATUS_SUCCESS = 'succeeded'.freeze
+      STATUS_RUN     = 'running'.freeze
+      STATUS_FAILURE = 'failed'.freeze
+
       Attributes = Struct.new(:jobnet_id, :job_id, :job_execution_id, :status, :message,
                               :submitted_at, :lock,:started_at, :finished_at, :source,
                               :job_name, :jobnet_name, :executor_id, :subsystem,
                               keyword_init: true)
 
-      def JobExecution.for_record(job_executions)
-        job_executions.map do |je|
-          je_sym_hash = Hash[ je.map{|k,v| [k.to_sym, v] } ]
+      def JobExecution.for_record(job_execution)
+          je_sym_hash = Hash[ job_execution.map{ |k,v| [k.to_sym, v] } ]
           Attributes.new(**je_sym_hash)
-        end
+      end
+
+      def JobExecution.for_records(job_executions)
+        job_executions.map { |je| JobExecution.for_record(je) }
       end
 
       def initialize(datasource)
@@ -40,7 +47,7 @@ module Bricolage
         if job_executions.empty?
           []
         else
-          JobExecution.for_record(job_executions)
+          JobExecution.for_records(job_executions)
         end
       end
 
@@ -64,7 +71,7 @@ module Bricolage
           SQL
         end
 
-        job_executions = JobExecution.for_record(job_executions)
+        job_executions = JobExecution.for_records(job_executions)
         JobExecutionState.job_executions_change(@datasource, job_executions)
         job_executions
       end
@@ -83,7 +90,7 @@ module Bricolage
           SQL
         end
 
-        job_executions = JobExecution.for_record(job_executions)
+        job_executions = JobExecution.for_records(job_executions)
         JobExecutionState.job_executions_change(@datasource, job_executions)
         job_executions
       end

--- a/lib/bricolage/dao/jobexecution.rb
+++ b/lib/bricolage/dao/jobexecution.rb
@@ -87,51 +87,6 @@ module Bricolage
         JobExecutionState.job_executions_change(@datasource, job_executions)
         job_executions
       end
-
-      private
-
-      def compile_set_expr(values_hash)
-        columns = values_hash.keys.map(&:to_s).join(', ')
-        values = values_hash.values.map{|v| convert_value(v) }.join(', ')
-        return columns, values
-      end
-
-      def convert_value(value)
-        if value == :now
-          'now()'
-        elsif value.nil?
-          "null"
-        elsif value == true or value == false
-          "#{value.to_s}"
-        elsif value.instance_of?(Integer) or value.instance_of?(Float)
-          "#{value.to_s}"
-        elsif value.instance_of?(String) or value.instance_of?(Pathname)
-          "#{s(value.to_s)}"
-        else
-          raise "invalid type for 'value' argument in JobExecution#convert_value: #{value} is #{value.class}"
-        end
-      end
-
-      def compile_where_expr(conds_hash)
-        conds_hash.map{|k,v| convert_cond(k,v) }.join(' and ')
-      end
-
-      def convert_cond(column, cond)
-        if cond.nil?
-          "#{column} is null"
-        elsif cond.instance_of?(Array) # not support subquery
-          in_clause = cond.map{|c| convert_cond(column, c)}.join(' or ')
-          "(#{in_clause})"
-        elsif cond == true or cond == false
-          "#{column} is #{cond.to_s}"
-        elsif cond.instance_of?(Integer) or cond.instance_of?(Float)
-          "#{column} = #{cond}"
-        elsif cond.instance_of?(String) or cond.instance_of?(Pathname)
-          "#{column} = #{s(cond.to_s)}"
-        else
-          raise "invalid type for 'cond' argument in JobExecution#convert_cond: #{cond} is #{cond.class}"
-        end
-      end
     end
 
     class JobExecutionState

--- a/lib/bricolage/dao/jobexecution.rb
+++ b/lib/bricolage/dao/jobexecution.rb
@@ -4,10 +4,10 @@ module Bricolage
 
       include  SQLUtils
 
-      Attributes = Struct.new(:jobnet_id, :subsystem, :job_id, :job_execution_id,
-                                :status, :message, :submitted_at, :lock,
-                                :started_at, :finished_at, :source, :job_name, :jobnet_name,
-                                keyword_init: true)
+      Attributes = Struct.new(:jobnet_id, :job_id, :job_execution_id, :status, :message,
+                              :submitted_at, :lock,:started_at, :finished_at, :source,
+                              :job_name, :jobnet_name, :executor_id, :subsystem,
+                              keyword_init: true)
 
       def JobExecution.for_record(job_executions)
         job_executions.map do |je|

--- a/lib/bricolage/dao/jobnet.rb
+++ b/lib/bricolage/dao/jobnet.rb
@@ -4,7 +4,15 @@ module Bricolage
 
       include SQLUtils
 
-      Attributes = Struct.new(:id, :subsystem, :jobnet_name)
+      Attributes = Struct.new(:id, :subsystem, :jobnet_name, :executor_id)
+
+      def JobNet.for_record(jobnet)
+        Attributes.new(*jobnet.values)
+      end
+
+      def JobNet.for_records(jobnets)
+        jobnets.map { |jobnet| JobNet.for_record(jobnet) }
+      end
 
       def initialize(datasource)
         @datasource = datasource
@@ -29,7 +37,7 @@ module Bricolage
         if jobnet.nil?
           nil
         else
-          Attributes.new(jobnet['jobnet_id'], jobnet['subsystem'], jobnet['jobnet_name'])
+          JobNet.for_record(jobnet)
         end
       end
 
@@ -43,7 +51,7 @@ module Bricolage
           SQL
         end
 
-        Attributes.new(jobnet['jobnet_id'], jobnet['subsystem'], jobnet['jobnet_name'])
+        JobNet.for_record(jobnet)
       end
 
       def find_or_create(subsystem, jobnet_name)

--- a/lib/bricolage/sqlutils.rb
+++ b/lib/bricolage/sqlutils.rb
@@ -24,6 +24,48 @@ module Bricolage
       time.strftime('%Y-%m-%d %H:%M:%S')
     end
 
+    def compile_set_expr(values_hash)
+      columns = values_hash.keys.map(&:to_s).join(', ')
+      values = values_hash.values.map{|v| convert_value(v) }.join(', ')
+      return columns, values
+    end
+
+    def convert_value(value)
+      if value == :now
+        'now()'
+      elsif value.nil?
+        "null"
+      elsif value == true or value == false
+        "#{value.to_s}"
+      elsif value.instance_of?(Integer) or value.instance_of?(Float)
+        "#{value.to_s}"
+      elsif value.instance_of?(String) or value.instance_of?(Pathname)
+        "#{s(value.to_s)}"
+      else
+        raise "invalid type for 'value' argument in JobExecution#convert_value: #{value} is #{value.class}"
+      end
+    end
+
+    def compile_where_expr(conds_hash)
+      conds_hash.map{|k,v| convert_cond(k,v) }.join(' and ')
+    end
+
+    def convert_cond(column, cond)
+      if cond.nil?
+        "#{column} is null"
+      elsif cond.instance_of?(Array) # not support subquery
+        in_clause = cond.map{|c| convert_cond(column, c)}.join(' or ')
+        "(#{in_clause})"
+      elsif cond == true or cond == false
+        "#{column} is #{cond.to_s}"
+      elsif cond.instance_of?(Integer) or cond.instance_of?(Float)
+        "#{column} = #{cond}"
+      elsif cond.instance_of?(String) or cond.instance_of?(Pathname)
+        "#{column} = #{s(cond.to_s)}"
+      else
+        raise "invalid type for 'cond' argument in JobExecution#convert_cond: #{cond} is #{cond.class}"
+      end
+    end
   end
 
 end

--- a/lib/bricolage/taskqueue.rb
+++ b/lib/bricolage/taskqueue.rb
@@ -234,7 +234,7 @@ module Bricolage
 
     def enqueue_job_executions
       @jobs.each do |job|
-        @jobexecution_dao.upsert(set: {status: 'waiting', job_id: job.id, message: nil})
+        job_execution = @jobexecution_dao.create(job.id, STATUS_WAIT)
       end
     end
 

--- a/lib/bricolage/taskqueue.rb
+++ b/lib/bricolage/taskqueue.rb
@@ -171,22 +171,18 @@ module Bricolage
       @jobs = job_refs.map {|jobref| @job_dao.find_or_create(jobref.subsystem.to_s, jobref.name, @jobnet.id) }
     end
 
-    def queued?
-      !@queue.empty?
-    end
-
     def consume_each
       lock_jobnet
 
       while task = self.next
-        job_execution = dequeuing
+        dequeuing
 
-        lock_job(job_execution.first.job_id)
+        lock_job(task.job_id)
 
         @ds.clear_connection_pool
         task_result = yield task # running execute_job
 
-        unlock_job(job_execution.first.job_id)
+        unlock_job(task.job_id)
 
         if task_result.success?
           dequeued
@@ -228,15 +224,16 @@ module Bricolage
       job_executions = @jobexecution_dao.where('j.subsystem': @jobs.map(&:subsystem).uniq,
                                                job_name: @jobs.map(&:job_name),
                                                jobnet_name: @jobnet.jobnet_name,
-      job_executions.each do |je|
-        enqueue JobTask.for_job_execution(je)
-      end
                                                status: [STATUS_WAIT, STATUS_RUN, STATUS_FAILURE])
+      job_executions.each { |je| enqueue(je) }
     end
 
     def enqueue_job_executions
       @jobs.each do |job|
         job_execution = @jobexecution_dao.create(job.id, STATUS_WAIT)
+        job_execution.job_name = job.job_name
+        job_execution.subsystem = job.subsystem
+        @queue.push JobTask.for_job_execution(job_execution)
       end
     end
 
@@ -289,15 +286,19 @@ module Bricolage
   end
 
   class JobTask
-    def initialize(job)
+    def initialize(job, job_execution=nil)
       @job = job
       @job_name = job.name
       @subsystem = job.subsystem
+      @job_id = job_execution&.job_id
+      @job_execution_id = job_execution&.job_execution_id
     end
 
     attr_reader :job
     attr_reader :subsystem
     attr_reader :job_name
+    attr_reader :job_id
+    attr_reader :job_execution_id
 
     def serialize
       [@job].join("\t")
@@ -309,7 +310,8 @@ module Bricolage
     end
 
     def JobTask.for_job_execution(job_execution)
-      new(JobNet::JobRef.new(job_execution.subsystem, job_execution.job_name, JobNet::Location.dummy))
+      jobref = JobNet::JobRef.new(job_execution.subsystem, job_execution.job_name, JobNet::Location.dummy)
+      new(jobref, job_execution)
     end
   end
 

--- a/lib/bricolage/taskqueue.rb
+++ b/lib/bricolage/taskqueue.rb
@@ -199,32 +199,34 @@ module Bricolage
       unlock_jobnet
     end
 
-    def enqueue(task)
-      @jobexecution_dao.update(where: {'j.subsystem': task.subsystem, job_name: task.job_name},
-      @queue.push task
+    def enqueue(job_execution)
+      job_execution_id = job_execution.job_execution_id
+      @jobexecution_dao.update(where: {job_execution_id: job_execution_id},
                                set:   {status: STATUS_WAIT, message: nil, submitted_at: :now, started_at: nil, finished_at: nil})
+      @queue.push JobTask.for_job_execution(job_execution)
     end
 
     def dequeuing
       task = @queue.first
-      @jobexecution_dao.update(where: {'j.subsystem': task.subsystem, job_name: task.job_name},
+      job_executions = @jobexecution_dao.update(where: {job_execution_id: task.job_execution_id},
                                                 set:   {status: STATUS_RUN, started_at: :now})
     end
 
     def dequeued
       task = @queue.shift
-      @jobexecution_dao.update(where: {'j.subsystem': task.subsystem, job_name: task.job_name},
+      @jobexecution_dao.update(where: {job_execution_id: task.job_execution_id},
                                set:   {status: STATUS_SUCCESS, finished_at: :now})
     end
 
     def fail_without_dequeue(task_result)
       task = @queue.first
-      @jobexecution_dao.update(where: {'j.subsystem': task.subsystem, job_name: task.job_name},
+      @jobexecution_dao.update(where: {job_execution_id: task.job_execution_id},
                                set:   {status: STATUS_FAILURE, message: task_result.message})
     end
 
     def restore
       job_executions = @jobexecution_dao.where('j.subsystem': @jobs.map(&:subsystem).uniq,
+                                               job_name: @jobs.map(&:job_name),
                                                jobnet_name: @jobnet.jobnet_name,
       job_executions.each do |je|
         enqueue JobTask.for_job_execution(je)
@@ -245,6 +247,7 @@ module Bricolage
     end
 
     def lock_job(job_id)
+      raise "Invalid job_id" if job_id.nil?
       lock_results = @job_dao.update(where: {job_id: job_id, executor_id: nil},
                                      set:   {executor_id: @executor_id})
       raise "Already locked id:#{job_id} job" if lock_results.empty?

--- a/lib/bricolage/taskqueue.rb
+++ b/lib/bricolage/taskqueue.rb
@@ -190,28 +190,28 @@ module Bricolage
     end
 
     def enqueue(task)
-      @jobexecution_dao.update(where: {subsystem: task.subsystem, job_name: task.job_name},
+      @jobexecution_dao.update(where: {'j.subsystem': task.subsystem, job_name: task.job_name},
                                set:   {status: 'waiting', message: nil, submitted_at: :now, started_at: nil, finished_at: nil})
       @queue.push task
     end
 
     def dequeuing
       task = @queue.first
-      @jobexecution_dao.update(where: {subsystem: task.subsystem, job_name: task.job_name},
+      @jobexecution_dao.update(where: {'j.subsystem': task.subsystem, job_name: task.job_name},
                                set:   {status: 'running', started_at: :now})
       task
     end
 
     def dequeued
       task = @queue.shift
-      @jobexecution_dao.update(where: {subsystem: task.subsystem, job_name: task.job_name},
+      @jobexecution_dao.update(where: {'j.subsystem': task.subsystem, job_name: task.job_name},
                                set:   {status: 'succeeded', finished_at: :now})
       task
     end
 
     def restore
-      job_executions = @jobexecution_dao.where(subsystem: @subsys,
-                                               jobnet_name: @jobnet_name,
+      job_executions = @jobexecution_dao.where('j.subsystem': @jobs.map(&:subsystem).uniq,
+                                               jobnet_name: @jobnet.jobnet_name,
                                                status: ['waiting', 'running', 'failed'])
 
       job_executions.each do |je|

--- a/lib/bricolage/taskqueue.rb
+++ b/lib/bricolage/taskqueue.rb
@@ -141,6 +141,12 @@ module Bricolage
   end
 
   class DatabaseTaskQueue < TaskQueue
+
+    STATUS_WAIT    = Bricolage::DAO::JobExecution::STATUS_WAIT
+    STATUS_SUCCESS = Bricolage::DAO::JobExecution::STATUS_SUCCESS
+    STATUS_RUN     = Bricolage::DAO::JobExecution::STATUS_RUN
+    STATUS_FAILURE = Bricolage::DAO::JobExecution::STATUS_FAILURE
+
     def DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, executor_id)
       jobnet_subsys, jobnet_name = jobnet_ref.name.delete('*').split('/')
       job_refs = jobnet_ref.refs - [jobnet_ref.start, *jobnet_ref.net_refs, jobnet_ref.end]
@@ -195,35 +201,35 @@ module Bricolage
 
     def enqueue(task)
       @jobexecution_dao.update(where: {'j.subsystem': task.subsystem, job_name: task.job_name},
-                               set:   {status: 'waiting', message: nil, submitted_at: :now, started_at: nil, finished_at: nil})
       @queue.push task
+                               set:   {status: STATUS_WAIT, message: nil, submitted_at: :now, started_at: nil, finished_at: nil})
     end
 
     def dequeuing
       task = @queue.first
       @jobexecution_dao.update(where: {'j.subsystem': task.subsystem, job_name: task.job_name},
-                               set:   {status: 'running', started_at: :now})
+                                                set:   {status: STATUS_RUN, started_at: :now})
     end
 
     def dequeued
       task = @queue.shift
       @jobexecution_dao.update(where: {'j.subsystem': task.subsystem, job_name: task.job_name},
-                               set:   {status: 'succeeded', finished_at: :now})
+                               set:   {status: STATUS_SUCCESS, finished_at: :now})
     end
 
     def fail_without_dequeue(task_result)
       task = @queue.first
       @jobexecution_dao.update(where: {'j.subsystem': task.subsystem, job_name: task.job_name},
-                               set:   {status: 'failed', message: task_result.message})
+                               set:   {status: STATUS_FAILURE, message: task_result.message})
     end
 
     def restore
       job_executions = @jobexecution_dao.where('j.subsystem': @jobs.map(&:subsystem).uniq,
                                                jobnet_name: @jobnet.jobnet_name,
-                                               status: ['waiting', 'running', 'failed'])
       job_executions.each do |je|
         enqueue JobTask.for_job_execution(je)
       end
+                                               status: [STATUS_WAIT, STATUS_RUN, STATUS_FAILURE])
     end
 
     def enqueue_job_executions
@@ -275,7 +281,7 @@ module Bricolage
       @job_dao.update(where: {job_id: @jobs.map(&:id)},
                       set:   {executor_id: nil})
       @jobexecution_dao.update(where: {'je.job_id': @jobs.map(&:id)},
-                               set:   {status: 'succeeded'})
+                               set:   {status: STATUS_SUCCESS})
     end
   end
 

--- a/schema/Schemafile
+++ b/schema/Schemafile
@@ -2,12 +2,14 @@ create_table "jobs", primary_key: "job_id", force: :cascade do |t|
   t.string  "subsystem", null: false
   t.string  "job_name",  null: false
   t.integer "jobnet_id"
+  t.string  "executor_id"
   t.index ["subsystem", "job_name", "jobnet_id"], name: "job_unique", unique: true, using: :btree
 end
 
 create_table "jobnets", primary_key: "jobnet_id", force: :cascade do |t|
   t.string "subsystem",   null: false
   t.string "jobnet_name", null: false
+  t.string "executor_id"
   t.index ["subsystem", "jobnet_name"], name: "jobnet_unique", unique: true, using: :btree
 end
 
@@ -16,7 +18,6 @@ create_table "job_executions", primary_key: "job_execution_id", force: :cascade 
   t.string   "message"
   t.datetime "submitted_at", default: -> { "now()" }, null: false
   t.integer  "job_id",       null: false
-  t.boolean  "lock", null: false
   t.datetime "started_at"
   t.datetime "finished_at"
   t.string   "source"

--- a/schema/Schemafile
+++ b/schema/Schemafile
@@ -21,7 +21,6 @@ create_table "job_executions", primary_key: "job_execution_id", force: :cascade 
   t.datetime "started_at"
   t.datetime "finished_at"
   t.string   "source"
-  t.index ["job_id"], name: "job_id_unique", unique: true, using: :btree
 end
 
 create_table "job_execution_states", primary_key: "job_execution_state_id", force: :cascade do |t|

--- a/test/test_c_streaming_load.rb
+++ b/test/test_c_streaming_load.rb
@@ -5,7 +5,7 @@ Bricolage::JobClass.get('streaming_load')
 module Bricolage
   class TestStreamingLoadJobClass_S3Queue < Test::Unit::TestCase
     def test_compile_name_pattern
-      q = StreamingLoadJobClass::S3Queue.new(data_source: nil, queue_path: nil, ctl_prefix: nil, persistent_path: nil, file_name: nil, logger: nil)
+      q = StreamingLoadJobClass::S3Queue.new(data_source: nil, ctl_ds: nil, queue_path: nil, ctl_prefix: nil, persistent_path: nil, file_name: nil, logger: nil)
       re = q.compile_name_pattern("%*%Y%m%d-%H%M_%Q.gz")
       assert_equal /\A[^\/]*(?<year>\d{4})(?<month>\d{2})(?<day>\d{2})\-(?<hour>\d{2})(?<minute>\d{2})_(?<seq>\d+)\.gz\z/, re
     end

--- a/test/test_taskqueue.rb
+++ b/test/test_taskqueue.rb
@@ -52,48 +52,61 @@ module Bricolage
     context = Context.for_application(home_path='test/home')
     datasource = context.get_data_source('psql', 'test_db')
     jobnet_path = Pathname.new('test/home/subsys/net1.jobnet')
-    jobnet = RootJobNet.load_auto(context, [jobnet_path]).jobnets.first
-    jobrefs = jobnet.refs - [jobnet.start, *jobnet.net_refs, jobnet.end]
+    jobnet_ref = RootJobNet.load_auto(context, [jobnet_path]).jobnets.first
+    jobrefs = jobnet_ref.refs - [jobnet_ref.start, *jobnet_ref.net_refs, jobnet_ref.end]
+
     jobtask1 = JobTask.new(jobrefs.pop)
     jobtask2 = JobTask.new(jobrefs.pop)
 
+    job_dao = Bricolage::DAO::Job.new(datasource)
+    jobnet_dao = Bricolage::DAO::JobNet.new(datasource)
+    jobnet = jobnet_dao.find_or_create('subsys','net1')
+    job1 = job_dao.find_or_create('subsys', 'job1', jobnet.id)
+    job2 = job_dao.find_or_create('subsys', 'job2', jobnet.id)
+
     teardown do
-      queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet)
-      queue.unlock
+      queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
       queue.clear
     end
 
+    test "#enqueue/#dequeuing/#dequeued" do
+      queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
+      assert_equal 0, queue.size
+      queue.enqueue jobtask1
+      assert_equal 1, queue.size
+      queue.dequeuing
+      assert_equal 1, queue.size
+      queue.dequeued
+      assert_equal 0, queue.size
+    end
+
     test "DatabaseTaskQueue.restore_if_exist" do
-      queue1 = DatabaseTaskQueue.restore_if_exist(datasource, jobnet)
+      queue1 = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
       assert_equal 0, queue1.size
       queue1.enqueue jobtask1
       queue1.enqueue jobtask2
       queue1.dequeuing
-      queue2 = DatabaseTaskQueue.restore_if_exist(datasource, jobnet)
+      queue2 = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
       assert_equal 2, queue2.size
     end
 
-    test "#save" do
-      queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet)
-      assert_false queue.queued?
-      queue.enqueue jobtask1
-      assert_true  queue.queued?
-    end
-
-    test "#lock" do
-      queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet)
-      queue.enqueue jobtask1
+    test "#lock_jobnet/#unlock_jobnet" do
+      queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
+      assert_false  queue.locked?
+      queue.lock_jobnet
+      assert_true  queue.locked?
+      queue.unlock_jobnet
       assert_false queue.locked?
-      queue.lock
-      assert_true  queue.locked?
     end
 
-    test "#unlock" do
-      queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet)
-      queue.enqueue jobtask1
-      queue.lock
+    test "#lock_job/#unlock_job" do
+      queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
+      assert_false  queue.locked?
+
+      queue.lock_job(job1.id)
       assert_true  queue.locked?
-      queue.unlock
+
+      queue.unlock_job(job1.id)
       assert_false queue.locked?
     end
   end

--- a/test/test_taskqueue.rb
+++ b/test/test_taskqueue.rb
@@ -71,18 +71,18 @@ module Bricolage
 
     test "#enqueue/#dequeuing/#dequeued" do
       queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
-      assert_equal 0, queue.size
+      assert_equal 2, queue.size
       queue.enqueue jobtask1
-      assert_equal 1, queue.size
+      assert_equal 3, queue.size
       queue.dequeuing
-      assert_equal 1, queue.size
+      assert_equal 3, queue.size
       queue.dequeued
-      assert_equal 0, queue.size
+      assert_equal 2, queue.size
     end
 
     test "DatabaseTaskQueue.restore_if_exist" do
       queue1 = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
-      assert_equal 0, queue1.size
+      assert_equal 2, queue1.size
       queue1.enqueue jobtask1
       queue1.enqueue jobtask2
       queue1.dequeuing


### PR DESCRIPTION
https://github.com/bricolages/bricolage/pull/124 のあとにrebaseして、draftからPR化します

今までjobと1対1になっていたjob executionを1対nにし、実行のたびに増えるようにします。
また、それにあわせてJobTaskまわりに改修を加えてjob_execution情報を格納できるようにします。

## commit内容
- 4cef9ca JobExecutionのリファクタ
- a76bf73 upsertをやめてcreateを使うようにする（実行のたびにレコードが増えるようになる）
- 5d5307f jobexecutionの指定をsubsystem/job_nameだったのをやめてjob_execution_id指定にする
- 11fac7e JobTaskにjob_executionの情報をもたせるようにする
  - DatabaseTaskQueueのときだけ入り、他のときはnilが入る


## 11fac7e で入った・発覚した変更について

bricolageが実行するrubyプロセス内での実質的案キューは`@queue`であり、その`@queue` に格納するオブジェクトで`job_execution`の`state`更新や`job`/`jobnets`の`lock`更新を行うようにします。このため、JobTask内部に`job_execution`のidや`job_id`を格納します。

このため `restore_if_exist`で呼ぶ`enqueue_job_executions`内部でJobTaskを`@queue`に詰めるため、`@queue`のサイズが変わるタイミングが既存の`FileTaskQueue`と異なるようになり、テスト内容も変更しました。

実行しそこないのJobがない（永続化されたQueueがない）時、`restore_if_exist`を実行直後は
FileTaskQueue: `@queue.size` は0（未enqueue、`JobNetRunner#enqueue_jobs`で詰める）
DatabaseTaskQueue: `@queue.size` はjobnet内部のjob数（つまりenqueue済）