### PR TITLE
Separate job execution by each execution

### DIFF
--- a/lib/bricolage/dao/jobexecution.rb
+++ b/lib/bricolage/dao/jobexecution.rb
@@ -4,16 +4,23 @@ module Bricolage
 
       include  SQLUtils
 
+      STATUS_WAIT    = 'waiting'.freeze
+      STATUS_SUCCESS = 'succeeded'.freeze
+      STATUS_RUN     = 'running'.freeze
+      STATUS_FAILURE = 'failed'.freeze
+
       Attributes = Struct.new(:jobnet_id, :job_id, :job_execution_id, :status, :message,
                               :submitted_at, :lock,:started_at, :finished_at, :source,
                               :job_name, :jobnet_name, :executor_id, :subsystem,
                               keyword_init: true)
 
-      def JobExecution.for_record(job_executions)
-        job_executions.map do |je|
-          je_sym_hash = Hash[ je.map{|k,v| [k.to_sym, v] } ]
+      def JobExecution.for_record(job_execution)
+          je_sym_hash = Hash[ job_execution.map{ |k,v| [k.to_sym, v] } ]
           Attributes.new(**je_sym_hash)
-        end
+      end
+
+      def JobExecution.for_records(job_executions)
+        job_executions.map { |je| JobExecution.for_record(je) }
       end
 
       def initialize(datasource)
@@ -40,7 +47,7 @@ module Bricolage
         if job_executions.empty?
           []
         else
-          JobExecution.for_record(job_executions)
+          JobExecution.for_records(job_executions)
         end
       end
 
@@ -64,7 +71,7 @@ module Bricolage
           SQL
         end
 
-        job_executions = JobExecution.for_record(job_executions)
+        job_executions = JobExecution.for_records(job_executions)
         JobExecutionState.job_executions_change(@datasource, job_executions)
         job_executions
       end
@@ -83,7 +90,7 @@ module Bricolage
           SQL
         end
 
-        job_executions = JobExecution.for_record(job_executions)
+        job_executions = JobExecution.for_records(job_executions)
         JobExecutionState.job_executions_change(@datasource, job_executions)
         job_executions
       end

--- a/lib/bricolage/dao/jobnet.rb
+++ b/lib/bricolage/dao/jobnet.rb
@@ -19,7 +19,7 @@ module Bricolage
       end
 
       def find_by(subsystem, jobnet_name)
-        jobnet = @datasource.open_shared_connection do |conn|
+        record = @datasource.open_shared_connection do |conn|
           conn.query_row(<<~SQL)
             select
                 jobnet_id
@@ -35,15 +35,15 @@ module Bricolage
           SQL
         end
 
-        if jobnet.nil?
+        if record.nil?
           nil
         else
-          JobNet.for_record(jobnet)
+          JobNet.for_record(record)
         end
       end
 
       def create(subsystem, jobnet_name)
-        jobnet = @datasource.open_shared_connection do |conn|
+        record = @datasource.open_shared_connection do |conn|
           conn.query_row(<<~SQL)
             insert into jobnets ("subsystem", jobnet_name)
                 values (#{s(subsystem)}, #{s(jobnet_name)})
@@ -52,7 +52,7 @@ module Bricolage
           SQL
         end
 
-        JobNet.for_record(jobnet)
+        JobNet.for_record(record)
       end
 
       def find_or_create(subsystem, jobnet_name)
@@ -62,7 +62,7 @@ module Bricolage
       def where(**args)
         where_clause = compile_where_expr(args)
 
-        jobnets = @datasource.open_shared_connection do |conn|
+        records = @datasource.open_shared_connection do |conn|
           conn.query_rows(<<~SQL)
             select
                 *
@@ -74,10 +74,10 @@ module Bricolage
           SQL
         end
 
-        if jobnets.empty?
+        if records.empty?
           []
         else
-          JobNet.for_records(jobnets)
+          JobNet.for_records(records)
         end
       end
 
@@ -87,27 +87,27 @@ module Bricolage
 
         where_clause = compile_where_expr(where)
 
-        jobnets = @datasource.open_shared_connection do |conn|
+        records = @datasource.open_shared_connection do |conn|
           conn.query_rows(<<~SQL)
             update jobnets set #{set_clause} where #{where_clause} returning *;
           SQL
         end
 
-        if jobnets.empty?
+        if records.empty?
           []
         else
-          JobNet.for_records(jobnets)
+          JobNet.for_records(records)
         end
       end
 
       def check_lock(jobnet_id)
-        jobnet = @datasource.open_shared_connection do |conn|
+        record = @datasource.open_shared_connection do |conn|
           conn.query_row(<<~SQL)
             select jobnet_id from jobnets where jobnet_id = #{jobnet_id} and executor_id is not null;
           SQL
         end
 
-        jobnet != nil
+        record != nil
       end
 
     end

--- a/lib/bricolage/exception.rb
+++ b/lib/bricolage/exception.rb
@@ -30,6 +30,10 @@ module Bricolage
   # Aquiring lock takes too long (e.g. VACUUM lock)
   class LockTimeout < JobFailure; end
 
+  # The executing jobnet or job is already locked.
+  # You should wait to unlock by another job execution or force to unlock manually.
+  class DoubleLockError < JobFailure; end
+
   # S3 related exceptions
   class S3Exception < JobFailureByException; end
 

--- a/lib/bricolage/taskqueue.rb
+++ b/lib/bricolage/taskqueue.rb
@@ -233,7 +233,7 @@ module Bricolage
 
     def enqueue_job_executions
       @jobs.each do |job|
-        @jobexecution_dao.upsert(set: {status: 'waiting', job_id: job.id, message: nil})
+        job_execution = @jobexecution_dao.create(job.id, STATUS_WAIT)
       end
     end
 

--- a/lib/bricolage/taskqueue.rb
+++ b/lib/bricolage/taskqueue.rb
@@ -265,7 +265,7 @@ module Bricolage
     end
 
     def unlock_help
-      "Jobs with these ID are locked: #{locked_jobs.map(&:id)}"
+      "update the job_id records to unlock from job tables: #{locked_jobs.map(&:id)}"
     end
 
     # for debug to test

--- a/schema/Schemafile
+++ b/schema/Schemafile
@@ -21,7 +21,6 @@ create_table "job_executions", primary_key: "job_execution_id", force: :cascade 
   t.datetime "started_at"
   t.datetime "finished_at"
   t.string   "source"
-  t.index ["job_id"], name: "job_id_unique", unique: true, using: :btree
 end
 
 create_table "job_execution_states", primary_key: "job_execution_state_id", force: :cascade do |t|

--- a/test/test_taskqueue.rb
+++ b/test/test_taskqueue.rb
@@ -103,10 +103,10 @@ module Bricolage
       queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
       assert_false  queue.locked?
 
-      queue.lock_job(job1.id)
+      queue.lock_job(jobtask1)
       assert_true  queue.locked?
 
-      queue.unlock_job(job1.id)
+      queue.unlock_job(jobtask1)
       assert_false queue.locked?
     end
   end

--- a/test/test_taskqueue.rb
+++ b/test/test_taskqueue.rb
@@ -55,39 +55,31 @@ module Bricolage
     jobnet_ref = RootJobNet.load_auto(context, [jobnet_path]).jobnets.first
     jobrefs = jobnet_ref.refs - [jobnet_ref.start, *jobnet_ref.net_refs, jobnet_ref.end]
 
-    jobtask1 = JobTask.new(jobrefs.pop)
-    jobtask2 = JobTask.new(jobrefs.pop)
-
-    job_dao = Bricolage::DAO::Job.new(datasource)
-    jobnet_dao = Bricolage::DAO::JobNet.new(datasource)
-    jobnet = jobnet_dao.find_or_create('subsys','net1')
-    job1 = job_dao.find_or_create('subsys', 'job1', jobnet.id)
-    job2 = job_dao.find_or_create('subsys', 'job2', jobnet.id)
-
     teardown do
-      queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
+      queue = DatabaseTaskQueue.new(datasource, 'subsys', 'net1', jobrefs, 'dummy_executor')
       queue.clear
     end
 
     test "#enqueue/#dequeuing/#dequeued" do
-      queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
+      queue = DatabaseTaskQueue.new(datasource, 'subsys', 'net1', jobrefs, 'dummy_executor')
+      assert_equal 0, queue.size
+      queue.enqueue_job_executions
       assert_equal 2, queue.size
-      queue.enqueue jobtask1
-      assert_equal 3, queue.size
       queue.dequeuing
-      assert_equal 3, queue.size
-      queue.dequeued
+      assert_equal 2, queue.size
+      e = queue.dequeued
+      assert_equal 1, queue.size
+      queue.enqueue e.first
       assert_equal 2, queue.size
     end
 
     test "DatabaseTaskQueue.restore_if_exist" do
       queue1 = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
       assert_equal 2, queue1.size
-      queue1.enqueue jobtask1
-      queue1.enqueue jobtask2
       queue1.dequeuing
+      queue1.dequeued
       queue2 = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
-      assert_equal 2, queue2.size
+      assert_equal 1, queue2.size
     end
 
     test "#lock_jobnet/#unlock_jobnet" do
@@ -101,12 +93,11 @@ module Bricolage
 
     test "#lock_job/#unlock_job" do
       queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
-      assert_false  queue.locked?
-
-      queue.lock_job(jobtask1)
+      assert_false queue.locked?
+      task = queue.next
+      queue.lock_job(task)
       assert_true  queue.locked?
-
-      queue.unlock_job(jobtask1)
+      queue.unlock_job(task)
       assert_false queue.locked?
     end
   end

--- a/test/test_taskqueue.rb
+++ b/test/test_taskqueue.rb
@@ -71,18 +71,18 @@ module Bricolage
 
     test "#enqueue/#dequeuing/#dequeued" do
       queue = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
-      assert_equal 0, queue.size
+      assert_equal 2, queue.size
       queue.enqueue jobtask1
-      assert_equal 1, queue.size
+      assert_equal 3, queue.size
       queue.dequeuing
-      assert_equal 1, queue.size
+      assert_equal 3, queue.size
       queue.dequeued
-      assert_equal 0, queue.size
+      assert_equal 2, queue.size
     end
 
     test "DatabaseTaskQueue.restore_if_exist" do
       queue1 = DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, 'dummy_executor')
-      assert_equal 0, queue1.size
+      assert_equal 2, queue1.size
       queue1.enqueue jobtask1
       queue1.enqueue jobtask2
       queue1.dequeuing


### PR DESCRIPTION
https://github.com/bricolages/bricolage/pull/124 の修正を前提としています
なのでこちらのPRは#124 マージ後にマージします

今までjobと1対1になっていたjob executionを1対nにし、実行のたびに増えるようにします。
また、それにあわせてJobTaskまわりに改修を加えてjob_execution情報を格納できるようにします。

## commit内容
- 4cef9ca JobExecutionのリファクタ
- a76bf73 upsertをやめてcreateを使うようにする（実行のたびにレコードが増えるようになる）
- 5d5307f jobexecutionの指定をsubsystem/job_nameだったのをやめてjob_execution_id指定にする
- 11fac7e JobTaskにjob_executionの情報をもたせるようにする
  - DatabaseTaskQueueのときだけ入り、他のときはnilが入る


## 11fac7e で入った・発覚した変更について

bricolageが実行するrubyプロセス内での実質的案キューは`@queue`であり、その`@queue` に格納するオブジェクトで`job_execution`の`state`更新や`job`/`jobnets`の`lock`更新を行うようにします。このため、JobTask内部に`job_execution`のidや`job_id`を格納します。

このため `restore_if_exist`で呼ぶ`enqueue_job_executions`内部でJobTaskを`@queue`に詰めるため、`@queue`のサイズが変わるタイミングが既存の`FileTaskQueue`と異なるようになり、テスト内容も変更しました。

実行しそこないのJobがない（永続化されたQueueがない）時、`restore_if_exist`を実行直後は
FileTaskQueue: `@queue.size` は0（未enqueue、`JobNetRunner#enqueue_jobs`で詰める）
DatabaseTaskQueue: `@queue.size` はjobnet内部のjob数（つまりenqueue済）