### PR TITLE
Fix execution of jobnet in jobnet for DatabaseTaskQueue

### DIFF
--- a/lib/bricolage/jobnetrunner.rb
+++ b/lib/bricolage/jobnetrunner.rb
@@ -105,7 +105,6 @@ module Bricolage
     def get_queue(opts, jobnet)
       if opts.db_name
         datasource = @ctx.get_data_source('psql', opts.db_name)
-        jobnet = jobnet.jobnets.first
         executor_id = get_executor_id(opts.executor_type)
         logger.info "DB connect: #{opts.db_name}"
         DatabaseTaskQueue.restore_if_exist(datasource, jobnet, executor_id)

--- a/lib/bricolage/taskqueue.rb
+++ b/lib/bricolage/taskqueue.rb
@@ -143,8 +143,9 @@ module Bricolage
   class DatabaseTaskQueue < TaskQueue
 
     def DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, executor_id)
-      jobnet_subsys, jobnet_name = jobnet_ref.name.delete('*').split('/')
-      job_refs = jobnet_ref.refs - [jobnet_ref.start, *jobnet_ref.net_refs, jobnet_ref.end]
+      jobnet_subsys, jobnet_name = jobnet_ref.start_jobnet.name.delete('*').split('/')
+      job_refs = jobnet_ref.sequential_jobs
+
       q = new(datasource, jobnet_subsys, jobnet_name, job_refs, executor_id)
 
       return q if q.locked?

--- a/test/home/subsys2/job1.job
+++ b/test/home/subsys2/job1.job
@@ -1,0 +1,1 @@
+class: noop

--- a/test/home/subsys2/job2.job
+++ b/test/home/subsys2/job2.job
@@ -1,0 +1,1 @@
+class: noop

--- a/test/home/subsys2/net.jobnet
+++ b/test/home/subsys2/net.jobnet
@@ -1,0 +1,4 @@
+job1
+-> subsys/job5
+-> *subsys/net1 # has 4 jobs
+-> job2


### PR DESCRIPTION
DatabaseTaskQueueを使ったジョブ実行をテストしていたところ、内部でjobnetを呼び出すjobnetの実行がうまくいっていませんでした。エラーにはならず、該当部分を読み飛ばして実行されてしまいます。

`jobnetrunner.rb` で読み込んだ後に作られる `RootJobNet` をそのまま使わず、`JobNetRef` にしてから `JobRef` を読みだそうとしていました。
そうではなく `RootJobNet#sequential_jobs` を使って対象となるjobnetに含まれる全 job一覧を引きだすようにします。

また、変更にあわせて元々おかしかったテストも修正&ケース追加しました。