### PR TITLE
Add clear_queue for database taskqueue

### DIFF
--- a/lib/bricolage/dao/job.rb
+++ b/lib/bricolage/dao/job.rb
@@ -104,6 +104,13 @@ module Bricolage
         end
       end
 
+      def delete(**args)
+        where_clause = compile_where_expr(args)
+        @datasource.open_shared_connection do |conn|
+          conn.query_rows("delete from jobs where #{where_clause};")
+        end
+      end
+
       def check_lock(job_ids)
         records = @datasource.open_shared_connection do |conn|
           conn.query_rows(<<~SQL)

--- a/lib/bricolage/dao/jobnet.rb
+++ b/lib/bricolage/dao/jobnet.rb
@@ -100,6 +100,13 @@ module Bricolage
         end
       end
 
+      def delete(**args)
+        where_clause = compile_where_expr(args)
+        @datasource.open_shared_connection do |conn|
+          conn.query_rows("delete from jobnets where #{where_clause};")
+        end
+      end
+
       def check_lock(jobnet_id)
         record = @datasource.open_shared_connection do |conn|
           conn.query_row(<<~SQL)

--- a/lib/bricolage/jobnetrunner.rb
+++ b/lib/bricolage/jobnetrunner.rb
@@ -58,7 +58,7 @@ module Bricolage
       end
 
       if opts.clear_queue?
-        clear_queue(opts)
+        clear_queue(opts, jobnet)
         exit EXIT_SUCCESS
       end
       queue = get_queue(opts, jobnet)
@@ -94,9 +94,10 @@ module Bricolage
       @ctx.logger
     end
 
-    def clear_queue(opts)
+    def clear_queue(opts, jobnet)
       if opts.db_name
-        opts ## TODO
+        datasource = @ctx.get_data_source('psql', opts.db_name)
+        DatabaseTaskQueue.clear_queue(datasource, jobnet)
       elsif path = get_queue_file_path(opts)
         FileUtils.rm_f path
       end


### PR DESCRIPTION
DBtaskqueueにおいて、ジョブが失敗したときにDB内部のキューを消す方法がなかったので既存の `--clear-queue` オプションにあわせて機能を追加しました。

また、併せてテスト用に使っていたメソッドを改名&作り直して、テストを複数回実行してもDBに影響が出ないようにDB内データを消す `DatabasetTaskQueue#reset` と各種DAOに`#delete` を追加しました。