### PR TITLE
Fix subsystem for task of DatabaseTaskQueue

### DIFF
--- a/lib/bricolage/dao/job.rb
+++ b/lib/bricolage/dao/job.rb
@@ -93,7 +93,9 @@ module Bricolage
         where_clause = compile_where_expr(where)
         records = @datasource.open_shared_connection do |conn|
           conn.query_rows(<<~SQL)
-            update jobs set #{set_clause} where #{where_clause} returning *;
+            update jobs set #{set_clause} where #{where_clause}
+                returning "job_id", "subsystem", "job_name", jobnet_id, "executor_id"
+            ;
           SQL
         end
 

--- a/lib/bricolage/dao/jobexecution.rb
+++ b/lib/bricolage/dao/jobexecution.rb
@@ -11,7 +11,7 @@ module Bricolage
       STATUS_CANCEL = 'canceled'.freeze
 
       Attributes = Struct.new(:jobnet_id, :job_id, :job_execution_id, :status, :message,
-                              :submitted_at, :lock,:started_at, :finished_at, :source,
+                              :submitted_at, :started_at, :finished_at, :source,
                               :job_name, :jobnet_name, :executor_id, :subsystem,
                               keyword_init: true)
 
@@ -33,10 +33,12 @@ module Bricolage
           conn.query_row(<<~SQL)
             insert into job_executions ("job_id", status)
                 values (#{job_id}, #{s(status)})
-                returning *
+                returning job_execution_id, status, message, job_id, source,
+                          submitted_at, started_at, finished_at
             ;
           SQL
         end
+
         job_execution = JobExecution.for_record(record)
         JobExecutionState.job_executions_change(@datasource, [job_execution])
         job_execution
@@ -48,8 +50,19 @@ module Bricolage
         records = @datasource.open_shared_connection do |conn|
           conn.query_rows(<<~SQL)
             select
-                *
+                job_execution_id
+                , jn.jobnet_id
+                , jn.jobnet_name
+                , j.job_id
+                , j.job_name
+                , j.executor_id as executor_id
                 , j.subsystem as subsystem
+                , status
+                , message
+                , source
+                , submitted_at
+                , started_at
+                , finished_at
             from
                 job_executions je
                 join jobs j using(job_id)
@@ -82,7 +95,9 @@ module Bricolage
             where
                 je.job_id = j.job_id
                 and #{where_clause}
-            returning *, j.subsystem as subsystem
+            returning job_execution_id, jn.jobnet_id, jn.jobnet_name, j.job_id, j.job_name,
+                      j.executor_id as executor_id, j.subsystem as subsystem,
+                      status, message, source, submitted_at, started_at, finished_at
             ;
           SQL
         end

--- a/lib/bricolage/dao/jobexecution.rb
+++ b/lib/bricolage/dao/jobexecution.rb
@@ -49,6 +49,7 @@ module Bricolage
           conn.query_rows(<<~SQL)
             select
                 *
+                , j.subsystem as subsystem
             from
                 job_executions je
                 join jobs j using(job_id)
@@ -81,7 +82,7 @@ module Bricolage
             where
                 je.job_id = j.job_id
                 and #{where_clause}
-            returning *
+            returning *, j.subsystem as subsystem
             ;
           SQL
         end

--- a/lib/bricolage/dao/jobnet.rb
+++ b/lib/bricolage/dao/jobnet.rb
@@ -65,7 +65,10 @@ module Bricolage
         records = @datasource.open_shared_connection do |conn|
           conn.query_rows(<<~SQL)
             select
-                *
+                jobnet_id
+                , "subsystem"
+                , jobnet_name
+                , executor_id
             from
                 jobnets
             where

--- a/lib/bricolage/taskqueue.rb
+++ b/lib/bricolage/taskqueue.rb
@@ -229,7 +229,7 @@ module Bricolage
 
     def restore
       job_executions = @jobexecution_dao.where('jn.subsystem': @jobnet.subsystem,
-                                               jobnet_name: @jobnet.jobnet_name,
+                                               'jn.jobnet_name': @jobnet.jobnet_name,
                                                status: [Bricolage::DAO::JobExecution::STATUS_WAIT,
                                                         Bricolage::DAO::JobExecution::STATUS_RUN,
                                                         Bricolage::DAO::JobExecution::STATUS_FAILURE])

--- a/lib/bricolage/taskqueue.rb
+++ b/lib/bricolage/taskqueue.rb
@@ -142,11 +142,10 @@ module Bricolage
 
   class DatabaseTaskQueue < TaskQueue
 
-    def DatabaseTaskQueue.restore_if_exist(datasource, jobnet_ref, executor_id)
-      jobnet_subsys, jobnet_name = jobnet_ref.start_jobnet.name.delete('*').split('/')
-      job_refs = jobnet_ref.sequential_jobs
+    def DatabaseTaskQueue.restore_if_exist(datasource, root_jobnet_ref, executor_id)
+      job_refs = root_jobnet_ref.sequential_jobs
 
-      q = new(datasource, jobnet_subsys, jobnet_name, job_refs, executor_id)
+      q = new(datasource, root_jobnet_ref, job_refs, executor_id)
 
       return q if q.locked?
 
@@ -163,7 +162,7 @@ module Bricolage
       q.clear
     end
 
-    def initialize(datasource, subsys, jobnet_name, job_refs, executor_id)
+    def initialize(datasource, root_jobnet_ref, job_refs, executor_id)
       super()
       @ds = datasource
       @jobnet_dao = Bricolage::DAO::JobNet.new(@ds)
@@ -171,8 +170,24 @@ module Bricolage
       @jobexecution_dao = Bricolage::DAO::JobExecution.new(@ds)
 
       @executor_id = executor_id
-      @jobnet = @jobnet_dao.find_or_create(subsys, jobnet_name)
-      @jobs = job_refs.map {|jobref| @job_dao.find_or_create(jobref.subsystem.to_s, jobref.name, @jobnet.id) }
+      @root_jobnet_ref = root_jobnet_ref
+      @root_jobnet = nil
+      @jobs = []
+      @jobnets = []
+
+      root_jobnet_ref.jobnets.each do |jobnet_ref|
+        subsys = jobnet_ref.ref.subsystem.to_s
+        jobnet_name = jobnet_ref.ref.name.to_s
+        jobnet = @jobnet_dao.find_or_create(subsys, jobnet_name)
+        @jobnets << jobnet
+        @root_jobnet = jobnet if @root_jobnet_ref.id == "#{jobnet.subsystem}/#{jobnet.jobnet_name}"
+
+        job_refs = jobnet_ref.refs - [jobnet_ref.start, *jobnet_ref.net_refs, jobnet_ref.end]
+        jobs = job_refs.map do |job_ref|
+          @job_dao.find_or_create(job_ref.subsystem.to_s, job_ref.name, jobnet.id)
+        end
+        @jobs.concat(jobs)
+      end
     end
 
     def consume_each
@@ -230,7 +245,7 @@ module Bricolage
     def restore
       job_executions = @jobexecution_dao.where('j.subsystem': @jobs.map(&:subsystem).uniq,
                                                job_name: @jobs.map(&:job_name),
-                                               jobnet_name: @jobnet.jobnet_name,
+                                               jobnet_name: @jobnets.map(&:jobnet_name).uniq,
                                                status: [Bricolage::DAO::JobExecution::STATUS_WAIT,
                                                         Bricolage::DAO::JobExecution::STATUS_RUN,
                                                         Bricolage::DAO::JobExecution::STATUS_FAILURE])
@@ -247,7 +262,7 @@ module Bricolage
     end
 
     def locked?
-      jobnet_lock = @jobnet_dao.check_lock(@jobnet.id)
+      jobnet_lock = @jobnet_dao.check_lock(@root_jobnet.id)
       jobs_lock = @job_dao.check_lock(@jobs.map(&:id))
       jobnet_lock || jobs_lock
     end
@@ -260,9 +275,9 @@ module Bricolage
     end
 
     def lock_jobnet
-      lock_results = @jobnet_dao.update(where: {jobnet_id: @jobnet.id, executor_id: nil},
+      lock_results = @jobnet_dao.update(where: {jobnet_id: @root_jobnet.id, executor_id: nil},
                                         set:   {executor_id: @executor_id})
-      raise DoubleLockError, "Already locked id:#{@jobnet.id} jobnet" if lock_results.empty?
+      raise DoubleLockError, "Already locked id:#{@root_jobnet.id} jobnet" if lock_results.empty?
     end
 
     def unlock_job(task)
@@ -271,12 +286,12 @@ module Bricolage
     end
 
     def unlock_jobnet
-      @jobnet_dao.update(where: {jobnet_id: @jobnet.id},
+      @jobnet_dao.update(where: {jobnet_id: @root_jobnet.id},
                          set:   {executor_id: nil})
     end
 
     def locked_jobs
-      @job_dao.where(jobnet_id: @jobnet.id).reject {|job| job.executor_id.nil? }
+      @job_dao.where(jobnet_id: @jobnets.map(&:id)).reject {|job| job.executor_id.nil? }
     end
 
     def unlock_help
@@ -292,7 +307,7 @@ module Bricolage
     def reset
       @jobexecution_dao.delete('je.job_execution_id': @queue.map(&:job_execution_id))
       @job_dao.delete(job_id: @jobs.map(&:id))
-      @jobnet_dao.delete(jobnet_id: @jobnet.id)
+      @jobnet_dao.delete(jobnet_id: @jobnets.map(&:id))
     end
   end
 

--- a/lib/bricolage/taskqueue.rb
+++ b/lib/bricolage/taskqueue.rb
@@ -228,8 +228,7 @@ module Bricolage
     end
 
     def restore
-      job_executions = @jobexecution_dao.where('j.subsystem': @jobs.map(&:subsystem).uniq,
-                                               job_name: @jobs.map(&:job_name),
+      job_executions = @jobexecution_dao.where('jn.subsystem': @jobnet.subsystem,
                                                jobnet_name: @jobnet.jobnet_name,
                                                status: [Bricolage::DAO::JobExecution::STATUS_WAIT,
                                                         Bricolage::DAO::JobExecution::STATUS_RUN,

--- a/test/test_taskqueue.rb
+++ b/test/test_taskqueue.rb
@@ -74,7 +74,7 @@ module Bricolage
     end
 
     test "#enqueue/#dequeuing/#dequeued" do
-      queue = DatabaseTaskQueue.new(datasource, 'subsys', 'net1', jobrefs, 'dummy_executor')
+      queue = DatabaseTaskQueue.new(datasource, jobnet_ref, jobrefs, 'dummy_executor')
 
       assert_equal 0, queue.size
       queue.enqueue_job_executions

--- a/test/test_taskqueue.rb
+++ b/test/test_taskqueue.rb
@@ -74,7 +74,7 @@ module Bricolage
     end
 
     test "#enqueue/#dequeuing/#dequeued" do
-      queue = DatabaseTaskQueue.new(datasource, jobnet_ref, jobrefs, 'dummy_executor')
+      queue = DatabaseTaskQueue.new(datasource, 'subsys', 'net1', jobrefs, 'dummy_executor')
 
       assert_equal 0, queue.size
       queue.enqueue_job_executions


### PR DESCRIPTION
`-l` オプションで jobnet内にあるjobnet（=subnet）のジョブキューがDatabaseTaskQueue版とFileTaskQueue版で一致するかを確認していたところ、一度DB内部に格納したキューを呼び出すときだけRootJobNetのsubsysteで上書きされていました。

`DAO::JobExecution` の読み出しが`jobnets`テーブル側の`subsystem` を読んでいたためです。
`jobs` テーブル側の`subssytem` を読み出す用に修正します。