### PR TITLE
Fix bug of execution_sequence about type from String to Integer

### DIFF
--- a/lib/bricolage/taskqueue.rb
+++ b/lib/bricolage/taskqueue.rb
@@ -233,7 +233,9 @@ module Bricolage
                                                status: [Bricolage::DAO::JobExecution::STATUS_WAIT,
                                                         Bricolage::DAO::JobExecution::STATUS_RUN,
                                                         Bricolage::DAO::JobExecution::STATUS_FAILURE])
-      job_executions.sort_by(&:execution_sequence).each { |je| enqueue(je) }
+      job_executions
+        .sort_by { |je| je.execution_sequence.to_i }
+        .each { |je| enqueue(je) }
     end
 
     def enqueue_job_executions


### PR DESCRIPTION
`JobExecution#where` で取得した job_executions はPGを経由して全てStringとして受け取っていました。このため、そのままの値で `Array#sort_by` してしまうと、辞書順ソートとなり `execution_sequence` が10を超えるとソート順がおかしくなります。

ソート時に `execution_sequence` を Integerに変換してからソートするようにします。