### PR TITLE
enhancements: Allows PSQLDataSource users to customize the logger

### DIFF
--- a/lib/bricolage/datasource.rb
+++ b/lib/bricolage/datasource.rb
@@ -137,7 +137,7 @@ module Bricolage
 
     attr_reader :name
     attr_reader :context
-    attr_reader :logger
+    attr_accessor :logger
 
     def open
       yield nil

--- a/lib/bricolage/logger.rb
+++ b/lib/bricolage/logger.rb
@@ -20,9 +20,16 @@ module Bricolage
 
     DEFAULT_ROTATION_SIZE = 1024 ** 2 * 100   # 100MB
 
-    def Logger.new(device: $stderr, rotation_period: nil, rotation_size: DEFAULT_ROTATION_SIZE)
+    def Logger.new(device: $stderr, level: nil, rotation_period: nil, rotation_size: DEFAULT_ROTATION_SIZE)
       logger = super(device, (rotation_period || 0), rotation_size)
-      logger.level = (device == $stderr && $stderr.tty?) ? Logger::DEBUG : Logger::INFO
+      logger.level =
+        if level
+          level
+        elsif device == $stderr && $stderr.tty?
+          Logger::DEBUG
+        else
+          Logger::INFO
+        end
       logger.formatter = -> (sev, time, prog, msg) {
         "#{time}: #{sev}: #{msg}\n"
       }

--- a/lib/bricolage/postgresconnection.rb
+++ b/lib/bricolage/postgresconnection.rb
@@ -87,7 +87,7 @@ module Bricolage
     private :querying
 
     def execute_update(query)
-      log_query query
+      log_query query, @ds.update_sql_log_level
       rs = log_elapsed_time {
         querying {
           @connection.async_exec(query)
@@ -128,7 +128,7 @@ module Bricolage
     end
 
     def execute_query(query, &block)
-      log_query query
+      log_query query, @ds.query_sql_log_level
       rs = log_elapsed_time {
         querying {
           @connection.async_exec(query)
@@ -262,8 +262,8 @@ module Bricolage
       execute("lock #{table}")
     end
 
-    def log_query(query)
-      @logger.log(@ds.sql_log_level) { "[#{@ds.name}] #{mask_secrets query}" }
+    def log_query(query, log_level = @ds.sql_log_level)
+      @logger.log(log_level) { "[#{@ds.name}] #{mask_secrets query}" }
     end
 
     def mask_secrets(msg)

--- a/lib/bricolage/psqldatasource.rb
+++ b/lib/bricolage/psqldatasource.rb
@@ -27,6 +27,8 @@ module Bricolage
         encoding: nil,
         psql: 'psql',
         sql_log_level: Logger::INFO,
+        query_sql_log_level: nil,
+        update_sql_log_level: nil,
         tmpdir: Dir.tmpdir)
       @host = host
       @port = port
@@ -37,6 +39,8 @@ module Bricolage
       @encoding = encoding
       @psql = psql
       @sql_log_level = Logger.intern_severity(sql_log_level)
+      @query_sql_log_level = Logger.intern_severity(query_sql_log_level || sql_log_level)
+      @update_sql_log_level = Logger.intern_severity(update_sql_log_level || sql_log_level)
       @tmpdir = tmpdir
       @connection_pool = []
       raise ParameterError, "missing psql host" unless @host
@@ -54,6 +58,8 @@ module Bricolage
     attr_reader :user
 
     attr_reader :sql_log_level
+    attr_reader :query_sql_log_level
+    attr_reader :update_sql_log_level
 
     def new_task
       PSQLTask.new(self)


### PR DESCRIPTION
For #137 第一弾

- psqlデータソースに新しいオプションquery_sql_log_levelとupdate_sql_log_levelを追加して、SELECT系とUPDATE系で別のログレベルを使えるようにした（いずれもデフォルト値はsql_log_level）。
- データソースのloggerを変更可能にした。
- Bricolage::Loggerのlevelをnewで指定できるようにした。

これでライブラリとして使っている場合はログに出すSQLをかなりコントロールできるようになる。