### PR TITLE
Use upper log threshold by default

### DIFF
--- a/lib/bricolage/context.rb
+++ b/lib/bricolage/context.rb
@@ -40,11 +40,16 @@ module Bricolage
     private_class_method :load
 
     def initialize(fs, env, option_variables: nil, data_sources: nil, logger: nil)
-      @logger = logger || Logger.default
+      @logger = logger || default_logger(env)
       @filesystem = fs
       @environment = env
       @option_variables = option_variables || Variables.new
       @data_sources = data_sources
+    end
+
+    private def default_logger(env)
+      level = (env == 'development') ? Logger::DEBUG : Logger::INFO
+      Logger.new(device: $stderr, level: level)
     end
 
     def load_configurations

--- a/lib/bricolage/logger.rb
+++ b/lib/bricolage/logger.rb
@@ -22,14 +22,7 @@ module Bricolage
 
     def Logger.new(device: $stderr, level: nil, rotation_period: nil, rotation_size: DEFAULT_ROTATION_SIZE)
       logger = super(device, (rotation_period || 0), rotation_size)
-      logger.level =
-        if level
-          level
-        elsif device == $stderr && $stderr.tty?
-          Logger::DEBUG
-        else
-          Logger::INFO
-        end
+      logger.level = level || Logger::INFO
       logger.formatter = -> (sev, time, prog, msg) {
         "#{time}: #{sev}: #{msg}\n"
       }

--- a/lib/bricolage/loglocator.rb
+++ b/lib/bricolage/loglocator.rb
@@ -70,21 +70,19 @@ module Bricolage
         FileUtils.rm_f(path)
         cleanup_local_dirs(File.dirname(path))
       rescue => ex
-        puts "warning: S3 upload failed: #{s3_url}"
+        $stderr.puts "warning: S3 upload failed: #{ex.class} #{ex.message}: #{s3_url}"
       end
     end
 
     # Removes empty directories recursively
     def cleanup_local_dirs(path)
       dir_path = path
-      until dir_path == '/'
-        begin
-          Dir.rmdir(dir_path)
-        rescue Errno::ENOTEMPTY
-          break
-        end
+      until dir_path == '/' or dir_path == '.'
+        Dir.rmdir(dir_path)
         dir_path = File.dirname(dir_path)
       end
+    rescue SystemCallError
+      return   # ignore
     end
   end
 end


### PR DESCRIPTION
これまでは「ログをstderrに吐いておりstderrが端末ならDEBUGレベル、それ以外はINFO」だったが、この条件だとDocker実行のときにもすべてDEBUGレベルになってしまう。

ちょっとださいが、とりあえず「BRICOLAGE_ENV=developmentのときにDEBUG、それ以外はINFO」にする。