### PR TITLE
[6.0beta] tmp: Prints a job log after uploading the file

### DIFF
--- a/lib/bricolage/loglocator.rb
+++ b/lib/bricolage/loglocator.rb
@@ -65,8 +65,9 @@ module Bricolage
       puts "bricolage: S3 log: #{s3_url}"
       begin
         @s3_writer.upload(path)
-        # tmp: Removes local file if S3 upload is succeeded.
+        # tmp: Prints & removes local file if S3 upload is succeeded.
         # It seems leaving local files causes unexpected Docker failure, I try to remove this.
+        puts File.read(path)
         FileUtils.rm_f(path)
         cleanup_local_dirs(File.dirname(path))
       rescue => ex


### PR DESCRIPTION
ログファイルをS3に上げるとき、printしてからローカルファイルを消す。
S3から手で持ってこないとログが見えない問題のとりあえずの対策。
これはこれで、ジョブネット内のログが全部ごちゃっと出力されてしまってよくない。