### PR TITLE
Default log level is always INFO

### DIFF
--- a/lib/bricolage/context.rb
+++ b/lib/bricolage/context.rb
@@ -48,8 +48,7 @@ module Bricolage
     end
 
     private def default_logger(env)
-      level = (env == 'development') ? Logger::DEBUG : Logger::INFO
-      Logger.new(device: $stderr, level: level)
+      Logger.new(device: $stderr, level: Logger::INFO)
     end
 
     def load_configurations


### PR DESCRIPTION
development環境ではDEBUGをデフォルトにしてみたが、そもそもbricolageのDEBUGログが出てもあまり意味はなく、それ以下のレベルがないためにログを消す方法もなくなってしまうので、常にINFOをデフォルトにする。

ログレベル変えるコマンドラインオプションも付けるべきだな。