### PR TITLE
fix: --clear-queue should cancel all queued jobs

### DIFF
--- a/lib/bricolage/context.rb
+++ b/lib/bricolage/context.rb
@@ -134,8 +134,11 @@ module Bricolage
 
     def load_variables(path)
       Variables.define {|vars|
-        @filesystem.config_file_loader.load_yaml(path).each do |name, value|
-          vars[name] = value
+        kvs = @filesystem.config_file_loader.load_yaml(path)
+        if kvs
+          kvs.each do |name, value|
+            vars[name] = value
+          end
         end
       }
     end

--- a/lib/bricolage/dao/jobexecution.rb
+++ b/lib/bricolage/dao/jobexecution.rb
@@ -1,7 +1,7 @@
 module Bricolage
   module DAO
-    class JobExecution
 
+    class JobExecution
       include  SQLUtils
 
       STATUS_WAIT    = 'waiting'.freeze
@@ -16,30 +16,45 @@ module Bricolage
                               keyword_init: true)
 
       def JobExecution.for_record(job_execution)
-          je_sym_hash = Hash[ job_execution.map{ |k,v| [k.to_sym, v] } ]
-          Attributes.new(**je_sym_hash)
+        je_sym_hash = Hash[ job_execution.map{ |k,v| [k.to_sym, v] } ]
+        Attributes.new(**je_sym_hash)
       end
 
       def JobExecution.for_records(job_executions)
         job_executions.map { |je| JobExecution.for_record(je) }
       end
 
-      def initialize(datasource)
+      def JobExecution.for_connection(conn)
+        new(nil, connection: conn)
+      end
+
+      def initialize(datasource, connection: nil)
         @datasource = datasource
+        @connection = connection
+      end
+
+      private def connect
+        if @connection
+          yield @connection
+        else
+          @datasource.open_shared_connection {|conn|
+            yield conn
+          }
+        end
       end
 
       def create(job_id, execution_sequence, status)
-        record = @datasource.open_shared_connection do |conn|
-          conn.query_row(<<~SQL)
+        records = @datasource.open_shared_connection {|conn|
+          conn.execute_update(<<~SQL)
             insert into job_executions ("job_id", execution_sequence, status)
                 values (#{job_id}, #{execution_sequence}, #{s(status)})
                 returning job_execution_id, execution_sequence, status, message, job_id, source,
                           submitted_at, started_at, finished_at
             ;
           SQL
-        end
+        }
 
-        job_execution = JobExecution.for_record(record)
+        job_execution = JobExecution.for_record(records.first)
         JobExecutionState.job_executions_change(@datasource, [job_execution])
         job_execution
       end
@@ -79,6 +94,33 @@ module Bricolage
         else
           JobExecution.for_records(records)
         end
+      end
+
+      def cancel_jobnet(jobnet_ref, message)
+        records = connect {|conn|
+          conn.execute_update(<<~SQL)
+            update job_executions
+            set
+                status = #{s STATUS_CANCEL}
+                , message = #{s message}
+                , started_at = now()
+                , finished_at = now()
+            where
+                job_id in (
+                    select
+                        j.job_id
+                    from
+                        jobs j inner join jobnets n using (jobnet_id)
+                    where
+                        n.subsystem = #{s jobnet_ref.subsystem}
+                        and n.jobnet_name = #{s jobnet_ref.name}
+                )
+                and status in (#{s STATUS_WAIT}, #{s STATUS_RUN}, #{s STATUS_FAILURE})
+            returning job_execution_id, job_id
+            ;
+          SQL
+        }
+        records.map {|r| JobExecution.for_record(r) }
       end
 
       def update(where:, set:)
@@ -146,7 +188,6 @@ module Bricolage
     end
 
     class JobExecutionState
-
       include SQLUtils
 
       def self.job_executions_change(datasource, job_executions)
@@ -161,8 +202,23 @@ module Bricolage
         end
       end
 
-      def initialize(datasource)
+      def JobExecutionState.for_connection(conn)
+        new(nil, connection: conn)
+      end
+
+      def initialize(datasource, connection: nil)
         @datasource = datasource
+        @connection = connection
+      end
+
+      private def connect
+        if @connection
+          yield @connection
+        else
+          @datasource.open_shared_connection {|conn|
+            yield conn
+          }
+        end
       end
 
       def create(job_execution_id:, status:, message:, job_id:)
@@ -171,6 +227,30 @@ module Bricolage
         @datasource.open_shared_connection do |conn|
           conn.execute("insert into job_execution_states (#{columns}) values (#{values});")
         end
+      end
+
+      def cancel_jobs(job_executions, message)
+        connect {|conn|
+          job_executions.each do |job_exec|
+            conn.execute(<<~EndSQL)
+              insert into job_execution_states
+              ( job_execution_id
+              , status
+              , message
+              , created_at
+              , job_id
+              )
+              values
+              ( #{job_exec.job_execution_id}
+              , #{s JobExecution::STATUS_CANCEL}
+              , #{s message}
+              , now()
+              , #{job_exec.job_id}
+              )
+              ;
+            EndSQL
+          end
+        }
       end
     end
   end

--- a/lib/bricolage/dao/jobnet.rb
+++ b/lib/bricolage/dao/jobnet.rb
@@ -18,7 +18,7 @@ module Bricolage
         @datasource = datasource
       end
 
-      def find_by(subsystem, jobnet_name)
+      private def find_by(ref)
         record = @datasource.open_shared_connection do |conn|
           conn.query_row(<<~SQL)
             select
@@ -29,8 +29,8 @@ module Bricolage
             from
                 jobnets
             where
-                "subsystem" = #{s(subsystem)}
-                and jobnet_name = #{s(jobnet_name)}
+                "subsystem" = #{s ref.subsystem}
+                and jobnet_name = #{s ref.name}
             ;
           SQL
         end
@@ -42,11 +42,11 @@ module Bricolage
         end
       end
 
-      def create(subsystem, jobnet_name)
+      private def create(ref)
         record = @datasource.open_shared_connection do |conn|
           conn.query_row(<<~SQL)
             insert into jobnets ("subsystem", jobnet_name)
-                values (#{s(subsystem)}, #{s(jobnet_name)})
+                values (#{s ref.subsystem}, #{s ref.name})
                 returning jobnet_id, "subsystem", jobnet_name
             ;
           SQL
@@ -55,8 +55,8 @@ module Bricolage
         JobNet.for_record(record)
       end
 
-      def find_or_create(subsystem, jobnet_name)
-        find_by(subsystem, jobnet_name) || create(subsystem, jobnet_name)
+      def find_or_create(ref)
+        find_by(ref) || create(ref)
       end
 
       def where(**args)

--- a/lib/bricolage/jobnet.rb
+++ b/lib/bricolage/jobnet.rb
@@ -51,6 +51,10 @@ module Bricolage
 
     attr_reader :start_jobnet
 
+    def ref
+      @start_jobnet.ref
+    end
+
     def each_jobnet(&block)
       @jobnets.each_value(&block)
     end

--- a/lib/bricolage/jobnet.rb
+++ b/lib/bricolage/jobnet.rb
@@ -351,7 +351,7 @@ module Bricolage
         unless node_subsys
           raise ParameterError, "missing subsystem: #{ref}"
         end
-        ref_class.new(node_subsys, name, location)
+        ref_class.new(node_subsys.to_s, name.to_s, location)
       end
 
       def initialize(subsys, name, location)
@@ -389,7 +389,7 @@ module Bricolage
 
     class JobRef < Ref
       def JobRef.for_path(path)
-        new(path.parent.basename, JobRef.strip_exts(path), Location.dummy)
+        new(path.parent.basename.to_s, JobRef.strip_exts(path), Location.dummy)
       end
 
       def JobRef.strip_exts(path)
@@ -398,7 +398,7 @@ module Bricolage
         until (ext = basename.extname).empty?
           basename = basename.basename(ext)
         end
-        basename
+        basename.to_s
       end
 
       def net?
@@ -408,11 +408,11 @@ module Bricolage
 
     class JobNetRef < Ref
       def JobNetRef.for_path(path)
-        new(path.parent.basename, path.basename('.jobnet'), Location.dummy)
+        new(path.parent.basename.to_s, path.basename('.jobnet').to_s, Location.dummy)
       end
 
       def JobNetRef.for_job_path(path)
-        new(path.parent.basename, JobRef.strip_exts(path), Location.dummy)
+        new(path.parent.basename.to_s, JobRef.strip_exts(path).to_s, Location.dummy)
       end
 
       def initialize(subsys, name, location)
@@ -443,7 +443,6 @@ module Bricolage
       def end_ref
         @end ||= JobRef.new(subsystem, "@#{name}@end", location)
       end
-
 
       def start
         @jobnet.start

--- a/lib/bricolage/jobnetrunner.rb
+++ b/lib/bricolage/jobnetrunner.rb
@@ -142,24 +142,23 @@ module Bricolage
     end
 
     def list_jobs(queue)
-      queue.each do |task|
-        puts task.job
+      queue.each do |job|
+        puts job
       end
     end
 
     def check_jobs(queue)
-      queue.each do |task|
-        Job.load_ref(task.job, @ctx).compile
+      queue.each do |job|
+        Job.load_ref(job, @ctx).compile
       end
     end
 
     def run_queue(queue)
       result = nil
-      task_job = nil
+      job = nil
       @hooks.run_before_all_jobs_hooks(BeforeAllJobsEvent.new(@jobnet_id, queue))
-      queue.consume_each do |task|
-        task_job = task.job
-        result = execute_job(task_job, queue)
+      queue.consume_each do |job|
+        result = execute_job(job, queue)
       end
       @hooks.run_after_all_jobs_hooks(AfterAllJobsEvent.new(result.success?, queue))
       logger.elapsed_time 'jobnet total: ', (Time.now - @jobnet_start_time)
@@ -167,7 +166,7 @@ module Bricolage
       if result.success?
         logger.info "status all green"
       else
-        logger.error "[job #{task_job}] #{result.message}"
+        logger.error "[job #{job}] #{result.message}"
         exit result.status
       end
     end

--- a/lib/bricolage/jobnetrunner.rb
+++ b/lib/bricolage/jobnetrunner.rb
@@ -113,7 +113,7 @@ module Bricolage
         logger.info "queue path: #{path}"
         FileTaskQueue.restore_if_exist(path)
       else
-        TaskQueue.new
+        MemoryTaskQueue.new
       end
     end
 

--- a/lib/bricolage/jobnetrunner.rb
+++ b/lib/bricolage/jobnetrunner.rb
@@ -101,7 +101,7 @@ module Bricolage
         logger.info "Enables DB queue: datasource=#{opts.db_name}"
         datasource = @ctx.get_data_source('psql', opts.db_name)
         executor_id = get_executor_id(opts.executor_type)
-        DatabaseTaskQueue.new(datasource: datasource, executor_id: executor_id)
+        DatabaseTaskQueue.new(datasource: datasource, executor_id: executor_id, enable_lock: false)
       elsif path = get_queue_file_path(opts)
         logger.info "Enables file queue: #{path}"
         FileTaskQueue.new(path: path)


### PR DESCRIPTION
DBキューで--clear-queueを実行するとき、エンキューしたときとキャンセルしたときでジョブネットの定義が変わっていると、エンキューされているジョブがジョブネットにもう存在しない場合がある。そのようなケースでジョブネットに定義されているジョブだけをキャンセルするとキャンセルしそこなうジョブがあるため、キュー内のジョブをすべて対象としてキャンセルすべき。

いろいろ修正を入れてしまったが一番肝心な変更は ff55f5d である。