### PR TITLE
fix: Pooled connection was not recycled on normal block exit

### DIFF
--- a/lib/bricolage/psqldatasource.rb
+++ b/lib/bricolage/psqldatasource.rb
@@ -128,6 +128,8 @@ module Bricolage
           logger.warn "Retry PG connection for execute query: #{ex.message}"
           sleep 1
           retry
+        else
+          raise
         end
       end
       if block_given?

--- a/lib/bricolage/psqldatasource.rb
+++ b/lib/bricolage/psqldatasource.rb
@@ -131,7 +131,11 @@ module Bricolage
         end
       end
       if block_given?
-        yield conn
+        begin
+          yield conn
+        ensure
+          conn.close
+        end
       else
         return conn
       end


### PR DESCRIPTION
コネクションプールの実装で、コネクションを閉じそこねる問題がいくつかあったので修正する。