### PR TITLE
new: Allows to refer job file variables (rest variables) from job parameters

### DIFF
--- a/lib/bricolage/job.rb
+++ b/lib/bricolage/job.rb
@@ -99,6 +99,7 @@ module Bricolage
       base_vars = Variables.union(
         #          ^ Low precedence
         @global_variables,
+        job_file_rest_vars,
         cmd_v_opt_vars,
         job_v_opt_vars
         #          v High precedence


### PR DESCRIPTION
For #161 

理由はまったく覚えていないのだが、ジョブパラメーターを展開するときにrest_variablesを入れてないのが原因だった。