### PR TITLE
Add Parquet and JSON to unload formats

### DIFF
--- a/jobclass/unload.rb
+++ b/jobclass/unload.rb
@@ -7,7 +7,7 @@ JobClass.define('unload') {
     params.add SrcTableParam.new(optional: false)
     params.add DataSourceParam.new('s3', 'dest-ds', 'Target data source (s3).')
     params.add DestFileParam.new
-    params.add EnumParam.new('format', %w(tsv csv), 'Data file format.', default: 'tsv')
+    params.add EnumParam.new('format', %w(tsv csv parquet json), 'Data file format.', default: 'tsv')
     params.add KeyValuePairsParam.new('options', 'OPTIONS', 'Loader options.',
         optional: true, default: PSQLLoadOptions.new,
         value_handler: lambda {|value, ctx, vars| PSQLLoadOptions.parse(value) })

--- a/lib/bricolage/psqldatasource.rb
+++ b/lib/bricolage/psqldatasource.rb
@@ -457,6 +457,10 @@ module Bricolage
         %q(delimiter '\t')
       when 'csv'
         %q(delimiter ',')
+      when 'parquet'
+        'format as parquet'
+      when 'json'
+        'format as json'
       else
         raise ParameterError, "unsupported format: #{fmt}"
       end


### PR DESCRIPTION
Parquet is supported since 2019-12-03.
https://aws.amazon.com/about-aws/whats-new/2019/12/announcing-amazon-redshift-data-lake-export/
JSON is supported since 2022-02-16.
https://aws.amazon.com/about-aws/whats-new/2022/02/amazon-redshift-unloading-data-json-files/