### PR TITLE
Allow to use aliases on config YAMLs

### DIFF
--- a/lib/bricolage/configloader.rb
+++ b/lib/bricolage/configloader.rb
@@ -42,7 +42,11 @@ module Bricolage
     private
 
     def parse_yaml(text, path)
-      YAML.load(text)
+      if Gem::Version.new(YAML::VERSION) >= Gem::Version.new("4.0.0")
+        YAML.load(text, aliases: true)
+      else
+        YAML.load(text)
+      end
     rescue => err
       raise ParameterError, "#{path}: config file syntax error: #{err.message}"
     end


### PR DESCRIPTION
Ruby 3.1 (or Psych 4.0) changes `Psych.load` behavior: https://github.com/ruby/psych/releases/tag/v4.0.0 

This commit allows to use aliases in config YAML because:

- Aliases are useful (especially for datasource.yml) and already used in Cookpad, and
- Config files are written by developers themselves.

I manually confirmed to pass tests on my local machine with Ruby 3.0.5 and Ruby 3.1.3, with/without modifications of `config/test/datasource.yml` as follows

```diff
--- a/config/test/datasource.yml
+++ b/config/test/datasource.yml
@@ -1,4 +1,4 @@
-test_db:
+test: &test
   type: psql
   host: localhost
   port: 5432
@@ -7,3 +7,6 @@ test_db:
   password: bricolage_test
   encoding: utf8
   sql_log_level: DEBUG
+
+test_db:
+  <<: *test
```
