### PR TITLE
Relax version constraint of pg gem

### DIFF
--- a/bricolage.gemspec
+++ b/bricolage.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.required_ruby_version = '>= 2.4.0'
-  s.add_dependency 'pg', '~> 1.2.3'
+  s.add_dependency 'pg', '~> 1.2', '>= 1.2.3'
   s.add_dependency 'aws-sdk-s3', '~> 1.64'
   s.add_dependency 'aws-sdk-sns', '~> 1.23'
   s.add_dependency 'nokogiri'   # aws-sdk-core requires this


### PR DESCRIPTION
In order to use bricolage with Ruby 3.2, we need pg >= 1.3.0: https://github.com/ged/ruby-pg/issues/413
Also, pg 1.4.0 and 1.4.1 fixes issues around keyword argument warnings on Ruby 2.7: https://github.com/ged/ruby-pg/blob/master/History.md#v141-2022-06-24-lars-kanis-larsgreiz-reinsdorfde

It seems there are no reasons to limit pg to '< 1.3', so I relax the current requirements to '>= 1.2.3' and '< 2'.

----

Also, I would appreciate if you could release a new version (6.0.0beta7?) of bricolage in order to use new bricolage by other gems.